### PR TITLE
add prev window position saver

### DIFF
--- a/main.js
+++ b/main.js
@@ -3,12 +3,16 @@ const {
     BrowserWindow,
     ipcMain
 } = require("electron")
+const Config = require('electron-config')
 
 let win
+let config = new Config()
 
 function createWindow() {
 
     win = new BrowserWindow({
+        x: config.get('position.x') || undefined,
+        y: config.get('position.y') || undefined,
         width: 886,
         height: 700,
         frame: false,
@@ -18,7 +22,6 @@ function createWindow() {
         maxHeight: 700,
         maximizable: false,
         resizable: false,
-        center: true,
         icon: './assets/img/icon.png'
     })
 
@@ -28,6 +31,12 @@ function createWindow() {
       win = null
     })
 
+    win.on("move", () => {
+        if (win !== null) {
+            saveWindowPosition(win)
+        }
+    })
+
     ipcMain.on("close-app", () => {
       app.quit()
     })
@@ -35,7 +44,13 @@ function createWindow() {
     ipcMain.on("minimize-app", () => {
       BrowserWindow.getFocusedWindow().minimize()
     })
+}
 
+function saveWindowPosition (window) {
+    let position = window.getPosition()
+
+    config.set('position.x', position[0])
+    config.set('position.y', position[1])
 }
 
 app.on("ready", createWindow)
@@ -48,5 +63,4 @@ app.on("activate", () => {
 
     if (win === null)
         createWindow()
-
 })

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "cpu-usage": "^0.1.0",
     "diskspace": "^1.0.3",
+    "electron-config": "^0.2.1",
     "exec": "^0.2.1",
     "jquery": "^3.1.1",
     "progressbar.js": "^1.0.1",
@@ -32,10 +33,10 @@
   },
   "scripts": {
     "start": "electron .",
-		"package-x86": "electron-packager . --overwrite --platform=linux --arch=ia32 --icon=assets/img/icon.png --prune=true --out=release-builds --version=1.4.11",
+    "package-x86": "electron-packager . --overwrite --platform=linux --arch=ia32 --icon=assets/img/icon.png --prune=true --out=release-builds --version=1.4.11",
     "package-x64": "electron-packager . --overwrite --platform=linux --arch=x64 --icon=assets/img/icon.png --prune=true --out=release-builds --version=1.4.11",
-		"build-x86":   "electron-installer-debian --src release-builds/Stacer-linux-ia32/ --arch i386 --dest dist/installers/ --icon assets/img/icon.png",
-    "build-x64":   "electron-installer-debian --src release-builds/Stacer-linux-x64/ --arch amd64 --dest dist/installers/ --icon assets/img/icon.png",
+    "build-x86": "electron-installer-debian --src release-builds/Stacer-linux-ia32/ --arch i386 --dest dist/installers/ --icon assets/img/icon.png",
+    "build-x64": "electron-installer-debian --src release-builds/Stacer-linux-x64/ --arch amd64 --dest dist/installers/ --icon assets/img/icon.png",
     "release-x86": "npm run package-x86 && npm run build-x86",
     "release-x64": "npm run package-x64 && npm run build-x64",
     "clean": "rm -r release-builds/ dist/"


### PR DESCRIPTION
In my case, I am using a dual monitor with my linux mint.
Every time it starts, Stacer is positioned at the center of two monitor than I'm in a little nervous.
consider this PR.
Thanks.