### PR TITLE
Added more colors to CPU history for 20 cores

### DIFF
--- a/src/components/resources/CpuHistory.js
+++ b/src/components/resources/CpuHistory.js
@@ -26,7 +26,10 @@ export default {
 				])
 
 			let cpuChart = new Chartkick.LineChart('cpus-chart', this.cpuData, {
-				colors: ['#2ecc71', '#e74c3c', '#3498db', '#f1c40f', '#9b59b6', '#34495e', '#1abc9c', '#e67e22'],
+				colors: ['#2ecc71', '#e74c3c', '#3498db', '#f1c40f', '#9b59b6', '#34495e',
+					 '#1abc9c', '#e67e22', '#46f0f0', '#f032e6', '#fabebe', '#008080',
+					 '#e6beff', '#aa6e28', '#d2f53c', '#800000', '#aaffc3', '#808000',
+					 '#000080', '#808080'],
 				legend: true,
 				min: 0,
 				max: 100,


### PR DESCRIPTION
Per an open issue: https://github.com/oguzhaninan/Stacer/issues/76

Expanded the existing 8 colors, one per core, to support 20 colors, one per core. Previously, colors for beyond 8 cores used the same dark gray color, making it impossible to distinguish which of the cores was being visualized.
Followed general color guidelines for visibility and uniqueness: https://sashat.me/2017/01/11/list-of-20-simple-distinct-colors/

Before
![image](https://user-images.githubusercontent.com/208641/28497592-f170e142-6f3f-11e7-9ccf-8e2e0c1e5748.png)

After
![image](https://user-images.githubusercontent.com/208641/28497594-066b2800-6f40-11e7-9188-d4d5230d2657.png)