### PR TITLE
Add CMake support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.4 FATAL_ERROR)
+project(Stacer)
+
+# Adding features(build cache + faster linkers) and reasonable defaults(Debug build by default)
+include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/cxxbasics/CXXBasics.cmake")
+
+# Setting a cleaner directory structure for the generated binaries
+set(CMAKE_BINARY_DIR        "${CMAKE_BINARY_DIR}/output")
+set(EXECUTABLE_OUTPUT_PATH  "${CMAKE_BINARY_DIR}/bin")
+set(LIBRARY_OUTPUT_PATH     "${CMAKE_BINARY_DIR}/lib")
+
+set(PROJECT_ROOT "${CMAKE_CURRENT_SOURCE_DIR}")
+
+# Activating MOC and searching for the Qt5 dependencies
+set(CMAKE_AUTOMOC ON)
+find_package(Qt5  COMPONENTS  Core Gui Charts Svg Concurrent  REQUIRED)
+
+# Setting the minimum C++ standard and passing the Qt-specific define
+set(CMAKE_CXX_STANDARD           11)
+set(CMAKE_CXX_EXTENSIONS         YES)
+set(CMAKE_CXX_STANDARD_REQUIRED  YES)
+add_definitions(-DQT_DEPRECATED_WARNINGS)
+
+# Subprojects
+add_subdirectory(stacer-core)
+add_subdirectory(stacer)

--- a/cmake/cxxbasics/CXXBasics.cmake
+++ b/cmake/cxxbasics/CXXBasics.cmake
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.4 FATAL_ERROR)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
+
+# Variables necessary in every module
+include(InitCXXBasics)
+
+# Set reasonable CMake defaults
+include(DefaultSettings)
+
+# Activate faster linkers by default
+include(accelerators/UseFasterLinkers)
+
+# Activate the compiler cache tool
+include(accelerators/UseCompilerCacheTool)
+
+# Allow the user to extend CXXBasics
+if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/../cxxbasics-extension.cmake")
+  include("${CMAKE_CURRENT_LIST_DIR}/../cxxbasics-extension.cmake")
+endif()

--- a/cmake/cxxbasics/DefaultSettings.cmake
+++ b/cmake/cxxbasics/DefaultSettings.cmake
@@ -1,0 +1,9 @@
+# This module sets reasonable defaults that probably every C/C++ CMake project should
+
+cmake_minimum_required(VERSION 3.4 FATAL_ERROR)
+
+# Default build type "Debug"
+opt_ifndef("Build Type(Debug, Release, RelWithDebInfo, MinSizeRel)"  STRING  "Debug"  CMAKE_BUILD_TYPE)
+
+# Generate "compile_commands.json" - tools like clang-tidy can be run on this file
+set(CMAKE_EXPORT_COMPILE_COMMANDS  ON)

--- a/cmake/cxxbasics/InitCXXBasics.cmake
+++ b/cmake/cxxbasics/InitCXXBasics.cmake
@@ -1,0 +1,13 @@
+## This module defines common functions and variables that should be accessible in every module
+
+cmake_minimum_required(VERSION 3.4 FATAL_ERROR)
+
+# Enable C and CXX by default. This allows to run some commands in script mode, or using "-C"
+enable_language(C)
+enable_language(CXX)
+
+# Project custom messaging macros
+include(helpers/MacroCustomMessages)
+
+# Widely-used macros to handle the cache variables
+include(helpers/MacroOpt)

--- a/cmake/cxxbasics/UNLICENSE
+++ b/cmake/cxxbasics/UNLICENSE
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <http://unlicense.org/>

--- a/cmake/cxxbasics/accelerators/UseCCache.cmake
+++ b/cmake/cxxbasics/accelerators/UseCCache.cmake
@@ -1,0 +1,15 @@
+# This module activates "ccache" support on Unix
+# This module is supposed to be used only from "UseCompilerCacheTool.cmake"
+
+cmake_minimum_required(VERSION 3.4 FATAL_ERROR)
+
+find_program(__cxxbasics_ccache_found  ccache)
+if(__cxxbasics_ccache_found)
+  if(NOT CMAKE_C_COMPILER_LAUNCHER)
+    set(CMAKE_C_COMPILER_LAUNCHER    ccache)
+  endif()
+
+  if(NOT CMAKE_CXX_COMPILER_LAUNCHER)
+    set(CMAKE_CXX_COMPILER_LAUNCHER  ccache)
+  endif()
+endif()

--- a/cmake/cxxbasics/accelerators/UseCompilerCacheTool.cmake
+++ b/cmake/cxxbasics/accelerators/UseCompilerCacheTool.cmake
@@ -1,0 +1,26 @@
+# This module activates a compiler cache
+
+cmake_minimum_required(VERSION 3.4 FATAL_ERROR)
+
+opt_ifndef("Use a compiler cache tool, if supported"  BOOL  ON  CXXBASICS_ACTIVATE_COMPILER_CACHE)
+if(CXXBASICS_ACTIVATE_COMPILER_CACHE)
+  if(CMAKE_HOST_UNIX)
+    include(accelerators/UseCCache)
+  endif()
+
+  if(NOT CMAKE_C_COMPILER_LAUNCHER OR NOT CMAKE_CXX_COMPILER_LAUNCHER)
+    include(accelerators/UseSCCache)
+  endif()
+
+  if(CMAKE_C_COMPILER_LAUNCHER)
+    cbok("Compiler cache tool \"${CMAKE_C_COMPILER_LAUNCHER}\" set for the C compiler")
+  else()
+    cbnok("Could not set a compiler cache tool for the C compiler")
+  endif()
+
+  if(CMAKE_CXX_COMPILER_LAUNCHER)
+    cbok("Compiler cache tool \"${CMAKE_CXX_COMPILER_LAUNCHER}\" set for the CXX compiler")
+  else()
+    cbnok("Could not set a compiler cache tool for the CXX compiler")
+  endif()
+endif()

--- a/cmake/cxxbasics/accelerators/UseFasterLinkers.cmake
+++ b/cmake/cxxbasics/accelerators/UseFasterLinkers.cmake
@@ -1,0 +1,97 @@
+# This module activates faster linkers, if these are available and supported.
+# It prefers the fastest linker available(as of this writing LLD -> GNU gold -> ...)
+# The linker is handled separately per compiler, so, you can do something like this:
+# -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=clang++
+
+cmake_minimum_required(VERSION 3.4 FATAL_ERROR)
+
+opt_ifndef("Use faster linkers(LLD, GNU gold...) if supported"  BOOL  ON  CXXBASICS_USE_FASTER_LINKERS)
+if(CXXBASICS_USE_FASTER_LINKERS)
+  macro(__cxxbasics_set_linker  compiler)
+    # Lets check if the default linker is not actually LLD or GNU gold(ex: a symbolic link)
+    execute_process(COMMAND ${compiler} -Wl,--version
+        OUTPUT_VARIABLE __cxxbasics_ld_version
+        ERROR_QUIET)
+
+    if("${__cxxbasics_ld_version}" MATCHES "LLD")
+      set(__cxxbasics_using_lld_linker ON)
+    elseif("${__cxxbasics_ld_version}" MATCHES "GNU gold")
+      set(__cxxbasics_using_gold_linker ON)
+    else()
+      set(__cxxbasics_using_default_linker ON)
+    endif()
+
+    # We don't do anything if the system linker already is the LLD linker, or links to it
+    if(NOT __cxxbasics_using_lld_linker)
+      # We try to set LLD first because it's the fastest linker currently
+      if(NOT __cxxbasics_using_lld_linker)
+        # LLD is currently production quality only on "x86_64"
+        include(compiler_detection/GetTargetArch)
+        if("${compiler}" STREQUAL "${CMAKE_C_COMPILER}")
+          set(__cxxbasics_target_arch "${CXXBASICS_C_COMPILER_TARGET_ARCH}")
+          set(__cxxbasics_current_compiler "CMAKE_C_COMPILER")
+        elseif("${compiler}" STREQUAL "${CMAKE_CXX_COMPILER}")
+          set(__cxxbasics_target_arch "${CXXBASICS_CXX_COMPILER_TARGET_ARCH}")
+          set(__cxxbasics_current_compiler "CMAKE_CXX_COMPILER")
+        else()
+          cberror("Could not obtain CMAKE_C_COMPILER nor CMAKE_CXX_COMPILER")
+        endif()
+
+        if("${__cxxbasics_target_arch}" STREQUAL "x86_64")
+          # Lets check if the compiler supports the LLD linker
+          execute_process(COMMAND ${compiler} -fuse-ld=lld -Wl,--version
+              OUTPUT_VARIABLE __cxxbasics_ld_version
+              ERROR_QUIET)
+
+          if("${__cxxbasics_ld_version}" MATCHES "LLD")
+            if("${__cxxbasics_current_compiler}" STREQUAL "CMAKE_C_COMPILER")
+              set(CMAKE_C_LINK_FLAGS "${CMAKE_C_LINK_FLAGS} -fuse-ld=lld")
+            else()
+              set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} -fuse-ld=lld")
+            endif()
+
+            set(__cxxbasics_using_lld_linker ON)
+            cbok("${__cxxbasics_current_compiler}(${compiler})'s linker set to: LLD linker")
+          endif()
+        endif("${__cxxbasics_target_arch}" STREQUAL "x86_64")
+      endif()
+
+      # We set the GNU gold linker if we failed to set LLD
+      if(NOT __cxxbasics_using_lld_linker AND NOT __cxxbasics_using_gold_linker)
+        execute_process(COMMAND ${compiler} -fuse-ld=gold -Wl,--version
+            OUTPUT_VARIABLE __cxxbasics_ld_version
+            ERROR_QUIET)
+
+        if("${__cxxbasics_ld_version}" MATCHES "GNU gold")
+          if("${__cxxbasics_current_compiler}" STREQUAL "CMAKE_C_COMPILER")
+            set(CMAKE_C_LINK_FLAGS "${CMAKE_C_LINK_FLAGS} -fuse-ld=gold")
+          else()
+            set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} -fuse-ld=gold")
+          endif()
+
+          set(__cxxbasics_using_gold_linker ON)
+          cbok("${__cxxbasics_current_compiler}(${compiler})'s linker is set to: GNU gold linker")
+        endif()
+      endif()
+
+      # If we failed to set LLD or the GNU gold linker, we fallback to the default linker
+      if(NOT __cxxbasics_using_lld_linker AND NOT __cxxbasics_using_gold_linker)
+        set(__cxxbasics_using_default_linker ON)
+        cbnok("${__cxxbasics_current_compiler}(${compiler})'s linker set to the fallback: default linker")
+      endif()
+    endif(NOT __cxxbasics_using_lld_linker)
+
+    unset(__cxxbasics_using_lld_linker)
+    unset(__cxxbasics_using_gold_linker)
+    unset(__cxxbasics_using_default_linker)
+    unset(__cxxbasics_ld_version)
+    unset(__cxxbasics_target_arch)
+    unset(__cxxbasics_current_compiler)
+  endmacro()
+
+  # Set the linker for the C compiler
+  __cxxbasics_set_linker("${CMAKE_C_COMPILER}")
+
+  # Set the linker for the CXX compiler
+  __cxxbasics_set_linker("${CMAKE_CXX_COMPILER}")
+endif()

--- a/cmake/cxxbasics/accelerators/UseSCCache.cmake
+++ b/cmake/cxxbasics/accelerators/UseSCCache.cmake
@@ -1,0 +1,16 @@
+# This module activates "sccache" support on Unix and Windows if
+# another compiler cache tool was not found.
+# This module is supposed to be used only from "UseCompilerCacheTool.cmake"
+
+cmake_minimum_required(VERSION 3.4 FATAL_ERROR)
+
+find_program(__cxxbasics_sccache_found  sccache)
+if(__cxxbasics_sccache_found)
+  if(NOT CMAKE_C_COMPILER_LAUNCHER)
+    set(CMAKE_C_COMPILER_LAUNCHER    sccache)
+  endif()
+
+  if(NOT CMAKE_CXX_COMPILER_LAUNCHER)
+    set(CMAKE_CXX_COMPILER_LAUNCHER  sccache)
+  endif()
+endif()

--- a/cmake/cxxbasics/compiler_detection/GetTargetArch.cmake
+++ b/cmake/cxxbasics/compiler_detection/GetTargetArch.cmake
@@ -1,0 +1,161 @@
+# This module identifies the target architecture of the C and CXX compilers
+
+# ARM("armv8" includes AArch64, "arm" is all the old ARM processors + Cortex-M): armv8, armv7, armv6, armv5, arm
+# Itanium:                                                                       ia64
+# Traditional PC architectures:                                                  x86, x86_64
+# MIPS(RISC):                                                                    mipsI, mipsII, mipsIII, mipsIV, mipsV, mips32, mips64, mips
+# PowerPC:                                                                       ppc64, ppc
+# IBM System z:                                                                  s390, s390x
+# SPARC:                                                                         sparcv9, sparc64, sparc
+
+cmake_minimum_required(VERSION 3.4 FATAL_ERROR)
+
+opt_ifndef("C compiler target architecture"    STRING  ""  CXXBASICS_C_COMPILER_TARGET_ARCH)
+opt_ifndef("CXX compiler target architecture"  STRING  ""  CXXBASICS_CXX_COMPILER_TARGET_ARCH)
+if("${CXXBASICS_C_COMPILER_TARGET_ARCH}" STREQUAL ""
+    OR "${CXXBASICS_CXX_COMPILER_TARGET_ARCH}" STREQUAL "")
+  include(helpers/FnMktemp)
+
+  mktemp()
+  if("${mktemp_result}" STREQUAL "")
+    opt_overwrite(CXXBASICS_TMP_FOLDER "${CMAKE_BINARY_DIR}")
+    mktemp()
+  endif()
+
+  ## Based on Qt 5.9 processor detection: https://github.com/qt/qtbase/blob/dev/src/corelib/global/qprocessordetection.h
+  file(WRITE "${mktemp_result}"
+      "
+      // ARM
+      #if defined(__arm__) || defined(__TARGET_ARCH_ARM) || defined(_M_ARM) || defined(__aarch64__)
+      #  if defined(__ARM64_ARCH_8__) \\
+            || defined(__aarch64__) \\
+            || defined(__CORE_CORTEXAV8__) // GHS-specific for INTEGRITY
+      #    define Q_PROCESSOR_ARM 8
+      #  elif defined(__ARM_ARCH_7__) \\
+            || defined(__ARM_ARCH_7A__) \\
+            || defined(__ARM_ARCH_7R__) \\
+            || defined(__ARM_ARCH_7M__) \\
+            || defined(__ARM_ARCH_7S__) \\
+            || defined(_ARM_ARCH_7) \\
+            || defined(__CORE_CORTEXA__) // GHS-specific for INTEGRITY
+      #    define Q_PROCESSOR_ARM 7
+      #  elif defined(__ARM_ARCH_6__) \\
+            || defined(__ARM_ARCH_6J__) \\
+            || defined(__ARM_ARCH_6T2__) \\
+            || defined(__ARM_ARCH_6Z__) \\
+            || defined(__ARM_ARCH_6K__) \\
+            || defined(__ARM_ARCH_6ZK__) \\
+            || defined(__ARM_ARCH_6M__)
+      #    define Q_PROCESSOR_ARM 6
+      #  elif defined(__ARM_ARCH_5TEJ__) \\
+              || defined(__ARM_ARCH_5TE__)
+      #    define Q_PROCESSOR_ARM 5
+      #  else
+      #    define Q_PROCESSOR_ARM 0
+      #  endif
+      #  if Q_PROCESSOR_ARM >= 8
+      #    error CMAKE_TARGET_ARCH armv8
+      #  endif
+      #  if Q_PROCESSOR_ARM >= 7
+      #    error CMAKE_TARGET_ARCH armv7
+      #  endif
+      #  if Q_PROCESSOR_ARM >= 6
+      #    error CMAKE_TARGET_ARCH armv6
+      #  endif
+      #  if Q_PROCESSOR_ARM >= 5
+      #    error CMAKE_TARGET_ARCH armv5
+      #  endif
+      #  error CMAKE_TARGET_ARCH arm // old ARM, Cortex-M...
+      #elif defined(__i386) || defined(__i386__) || defined(_M_IX86) // x86
+      #  error CMAKE_TARGET_ARCH x86
+      #elif defined(__x86_64) || defined(__x86_64__) || defined(__amd64) || defined(_M_X64) // x86_64
+      #  error CMAKE_TARGET_ARCH x86_64
+      #elif defined(__ia64) || defined(__ia64__) || defined(_M_IA64) // Itanium
+      #  error CMAKE_TARGET_ARCH ia64
+      #elif defined(__mips) || defined(__mips__) || defined(_M_MRX000) // MIPS(RISC)
+      #  if defined(_MIPS_ARCH_MIPS1) || (defined(__mips) && __mips - 0 >= 1)
+      #    error CMAKE_TARGET_ARCH mipsI
+      #  endif
+      #  if defined(_MIPS_ARCH_MIPS2) || (defined(__mips) && __mips - 0 >= 2)
+      #    error CMAKE_TARGET_ARCH mipsII
+      #  endif
+      #  if defined(_MIPS_ARCH_MIPS3) || (defined(__mips) && __mips - 0 >= 3)
+      #    error CMAKE_TARGET_ARCH mipsIII
+      #  endif
+      #  if defined(_MIPS_ARCH_MIPS4) || (defined(__mips) && __mips - 0 >= 4)
+      #    error CMAKE_TARGET_ARCH mipsIV
+      #  endif
+      #  if defined(_MIPS_ARCH_MIPS5) || (defined(__mips) && __mips - 0 >= 5)
+      #    error CMAKE_TARGET_ARCH mipsV
+      #  endif
+      #  if defined(_MIPS_ARCH_MIPS32) || defined(__mips32) || (defined(__mips) && __mips - 0 >= 32)
+      #    error CMAKE_TARGET_ARCH mips32
+      #  endif
+      #  if defined(_MIPS_ARCH_MIPS64) || defined(__mips64)
+      #    error CMAKE_TARGET_ARCH mips64
+      #  endif
+      #  error CMAKE_TARGET_ARCH mips // Unknown MIPS
+      #elif defined(__ppc__) || defined(__ppc) || defined(__powerpc__) \\
+            || defined(_ARCH_COM) || defined(_ARCH_PWR) || defined(_ARCH_PPC)  \\
+            || defined(_M_MPPC) || defined(_M_PPC)
+      #  if defined(__ppc64__) || defined(__powerpc64__) || defined(__64BIT__)
+      #    error CMAKE_TARGET_ARCH ppc64 // PowerPC 64
+      #  endif
+      #  error CMAKE_TARGET_ARCH ppc // PowerPC
+      #elif defined(__s390__) // IBM System z(s390/s390x)
+      #  if defined(__s390x__)
+      #    error CMAKE_TARGET_ARCH s390x
+      #  endif
+      #  error CMAKE_TARGET_ARCH s390
+      #elif defined(__sparc__) // SPARC
+      #  if defined(__sparc_v9__)
+      #    error CMAKE_TARGET_ARCH sparcv9
+      #  endif
+      #  if defined(__sparc64__)
+      #    error CMAKE_TARGET_ARCH sparc64
+      #  endif
+      #  error CMAKE_TARGET_ARCH sparc
+      #endif
+
+      #error CMAKE_TARGET_ARCH unknown
+      ")
+
+  macro(__cxxbasics_define_arch  suffix  variable)
+    file(RENAME "${mktemp_result}" "${mktemp_result}${suffix}")
+    set(mktemp_result "${mktemp_result}${suffix}")
+
+    try_compile(run_unused_result
+        "${CMAKE_CURRENT_BINARY_DIR}"
+        SOURCES "${mktemp_result}"
+        OUTPUT_VARIABLE TARGET_ARCH
+    )
+
+    if("${TARGET_ARCH}" MATCHES "CMAKE_TARGET_ARCH")
+      # Extracting the first "CMAKE_TARGET_ARCH [arch]"
+      string(REGEX MATCH "CMAKE_TARGET_ARCH ([A-Za-z0-9_]+)" TARGET_ARCH "${TARGET_ARCH}")
+
+      # Remove "CMAKE_TARGET_ARCH" and leaving only the architecture
+      string(REPLACE "CMAKE_TARGET_ARCH " "" TARGET_ARCH "${TARGET_ARCH}")
+
+      # Lets see if it is not unknown, otherwise we know we have the correct architecture in TARGET_ARCH
+      if("${TARGET_ARCH}" STREQUAL "unknown")
+        opt_overwrite(${variable} "unknown")
+      else()
+        opt_overwrite(${variable} "${TARGET_ARCH}")
+      endif()
+    else()
+      # If for some reason we didn't get the expected string, set the arch to "unknown"
+      opt_overwrite(${variable} "unknown")
+    endif()
+
+    # Catching coding errors
+    if("${variable}" STREQUAL "")
+      opt_overwrite(${variable} "unknown")
+    endif()
+
+    cbmessage("`${variable}` set to \"${${variable}}\"")
+  endmacro()
+
+  __cxxbasics_define_arch(".c"    CXXBASICS_C_COMPILER_TARGET_ARCH)
+  __cxxbasics_define_arch(".cxx"  CXXBASICS_CXX_COMPILER_TARGET_ARCH)
+endif()

--- a/cmake/cxxbasics/helpers/FnMktemp.cmake
+++ b/cmake/cxxbasics/helpers/FnMktemp.cmake
@@ -1,0 +1,70 @@
+## This module defines helper functions to create temporary files and folders in a system-agnostic way
+
+cmake_minimum_required(VERSION 3.4 FATAL_ERROR)
+
+opt_ifndef("CXXBasics temporary folder(uses system folder by default)"  PATH  ""  CXXBASICS_TMP_FOLDER)
+macro(__cxxbasics_mktemp_helper)
+  # Try to catch wrong usage
+  if(NOT "${ARGV0}" STREQUAL "file" AND NOT "${ARGV0}" STREQUAL "directory")
+    cberror("Wrong use of the macro")
+  endif()
+
+  # If `CXXBASICS_TMP_FOLDER` is not defined or set to an empty string, than we will try to set it to the system TMP
+  if(NOT DEFINED CXXBASICS_TMP_FOLDER OR NOT IS_DIRECTORY "${CXXBASICS_TMP_FOLDER}")
+    if(CMAKE_HOST_WIN32)
+      opt_overwrite(CXXBASICS_TMP_FOLDER "$ENV{TMP}")
+    elseif(CMAKE_HOST_UNIX)
+      opt_overwrite(CXXBASICS_TMP_FOLDER "/tmp")
+    else()
+      cberror("Unsupported OS. Cannot set the temporary folder, please manually modify CXXBASICS_TMP_FOLDER in the cache")
+    endif()
+  endif(NOT DEFINED CXXBASICS_TMP_FOLDER OR NOT IS_DIRECTORY "${CXXBASICS_TMP_FOLDER}")
+
+  # Lets make sure it's actually a directory
+  if(NOT IS_DIRECTORY "${CXXBASICS_TMP_FOLDER}")
+    cberror("`${CXXBASICS_TMP_FOLDER}` is not a folder. Please manually modify CXXBASICS_TMP_FOLDER in the cache")
+  endif()
+
+  # We will try to generate different random names until we are sure that it is unique for the path we try to use
+  opt_ifndef("Project prefix to be used when creating files and folders"  STRING  "cxxbasics"  CXXBASICS_PROJECT_PREFIX)
+  string(RANDOM LENGTH 16 random_generated_string)
+  file(TO_NATIVE_PATH "${CXXBASICS_TMP_FOLDER}/${CXXBASICS_PROJECT_PREFIX}_${random_generated_string}" mktemp_result)
+  while(EXISTS "${mktemp_result}")
+    string(RANDOM LENGTH 16 random_generated_string)
+    file(TO_NATIVE_PATH "${CXXBASICS_TMP_FOLDER}/${CXXBASICS_PROJECT_PREFIX}_${random_generated_string}" mktemp_result)
+  endwhile(EXISTS "${mktemp_result}")
+
+  # Here the behavior between `file` and `directory` splits, so we handle them separately
+  if("${ARGV0}" STREQUAL "file")
+    set(mktemp_result "${mktemp_result}" PARENT_SCOPE)
+    file(WRITE "${mktemp_result}" "")
+
+    # file(WRITE) should throw an error but we'll check anyway
+    if(NOT EXISTS "${mktemp_result}" OR IS_DIRECTORY "${mktemp_result}")
+      cbnok("Failed to create the temporary file")
+      unset(mktemp_result PARENT_SCOPE)
+    endif()
+  else()
+    set(mktemp_directory_result "${mktemp_result}")
+    set(mktemp_directory_result "${mktemp_directory_result}" PARENT_SCOPE)
+    file(MAKE_DIRECTORY "${mktemp_directory_result}")
+
+    # file(MAKE_DIRECTORY) should throw an error but we'll check anyway
+    if(NOT IS_DIRECTORY "${mktemp_directory_result}")
+      cbnok("Failed to create the temporary folder")
+      unset(mktemp_directory_result PARENT_SCOPE)
+    endif()
+  endif()
+endmacro()
+
+# @function mktemp
+# @return mktemp_result - stores the path to the temporary file
+function(mktemp)
+  __cxxbasics_mktemp_helper("file")
+endfunction()
+
+# @function mktemp_directory
+# @return mktemp_directory_result - stores the path to the temporary folder
+function(mktemp_directory)
+  __cxxbasics_mktemp_helper("directory")
+endfunction()

--- a/cmake/cxxbasics/helpers/MacroCustomMessages.cmake
+++ b/cmake/cxxbasics/helpers/MacroCustomMessages.cmake
@@ -1,0 +1,60 @@
+## This module contains project-wide custom CMake messagging macros.
+## Does not adhere to the overall style because MacroCbmessage does not sound very well nor represent all macros...
+
+cmake_minimum_required(VERSION 3.4 FATAL_ERROR)
+
+# This does not work in Windows CMD(usually also CI)
+if(CYGWIN OR NOT CMAKE_HOST_WIN32)
+  string(ASCII 27 __cxxbasics_escape)
+  set(__cxxbasics_prefix_color  "${__cxxbasics_escape}[36m") # Cyan
+  set(__cxxbasics_success_color "${__cxxbasics_escape}[32m") # Green
+  set(__cxxbasics_failure_color "${__cxxbasics_escape}[31m") # Red
+  set(__cxxbasics_no_color      "${__cxxbasics_escape}[m")   # Reset color
+
+  unset(__cxxbasics_escape)
+endif()
+
+set(__cxxbasics_prefix  "[${__cxxbasics_prefix_color}cxxbasics${__cxxbasics_no_color}]")
+set(__cxxbasics_success "[${__cxxbasics_success_color}✓${__cxxbasics_no_color}]")
+set(__cxxbasics_failure "[${__cxxbasics_failure_color}✗${__cxxbasics_no_color}]")
+
+unset(__cxxbasics_prefix_color)
+unset(__cxxbasics_success_color)
+unset(__cxxbasics_failure_color)
+unset(__cxxbasics_no_color)
+
+#========================================================
+
+# Use `_cbp` when displaying a simple message.
+# `cbp` stands for [C]XX[B]asics [P]refix
+set(_cbp   "${__cxxbasics_prefix}")
+
+# Use `_cbok` when displaying a notification of success(ex: `cxxbasics` succeded to set up ccache)
+# `cbok` stands for [C]XX[B]asics [OK]
+set(_cbok  "${_cbp}${__cxxbasics_success}")
+
+# Use `_cbnok` when displaying a notification of failure(ex: the user activated `ccache` but it was not found in the system)
+# `cbnok` stands for [C]XX[B]asics [N]ot [OK]
+set(_cbnok "${_cbp}${__cxxbasics_failure}")
+
+macro(cbmessage)
+  message(STATUS "${_cbp} " ${ARGV})
+endmacro(cbmessage)
+
+macro(cbok)
+  message(STATUS "${_cbok} " ${ARGV})
+endmacro(cbok)
+
+macro(cbnok)
+  message(STATUS "${_cbnok} " ${ARGV})
+endmacro(cbnok)
+
+macro(cberror)
+  message(FATAL_ERROR "${_cbnok} " ${ARGV})
+endmacro(cberror)
+
+#========================================================
+
+unset(__cxxbasics_prefix)
+unset(__cxxbasics_success)
+unset(__cxxbasics_failure)

--- a/cmake/cxxbasics/helpers/MacroOpt.cmake
+++ b/cmake/cxxbasics/helpers/MacroOpt.cmake
@@ -1,0 +1,57 @@
+## This module defines helper macros to set options(cached variables)
+
+cmake_minimum_required(VERSION 3.4 FATAL_ERROR)
+
+# @macro opt
+# Macro helper to set a cache value.
+# Does not overwrite the value if it was already cached.
+#
+# `description` - the description that will be displayed in CMake cache editor
+# `var_type`    - the type of the variable(BOOL, FILEPATH, PATH, STRING, INTERNAL)
+# `var_value`   - the value `var_name` will be set to
+# `var_name`    - variable name
+macro(opt  description  var_type  var_value  var_name)
+  set(${var_name}  ${var_value} CACHE ${var_type}  "${description}")
+
+  # Stores internally information about this variable's description and type
+  # Will be reused in `opt_overwrite` to make the macro easy to use
+  set(${var_name}_DESCRIPTION "${description}" CACHE INTERNAL "")
+  set(${var_name}_TYPE        "${var_type}"    CACHE INTERNAL "")
+endmacro()
+
+# @macro opt_ifndef
+# Macro helper to set a cache value.
+# Sets the cache value only if the variable(including local variables) was not defined or it is set to an empty string.
+macro(opt_ifndef  description  var_type  var_value  var_name)
+  if(NOT DEFINED ${var_name} OR "${${var_name}}" STREQUAL "")
+    set(${var_name}  ${var_value} CACHE ${var_type}  "${description}"  FORCE)
+
+    set(${var_name}_DESCRIPTION "${description}" CACHE INTERNAL "")
+    set(${var_name}_TYPE        "${var_type}"    CACHE INTERNAL "")
+  endif()
+endmacro()
+
+# @macro opt_force
+# Macro helper to set a cache value.
+# Sets the cache value or overwrites the value if the variable already exists.
+macro(opt_force  description  var_type  var_value  var_name)
+  set(${var_name}  ${var_value} CACHE ${var_type}  "${description}"  FORCE)
+
+  set(${var_name}_DESCRIPTION "${description}" CACHE INTERNAL "")
+  set(${var_name}_TYPE        "${var_type}"    CACHE INTERNAL "")
+endmacro()
+
+# @macro opt_overwrite
+# Macro helper to set a cache value.
+# Overwrites the cache value only if the variable already exists in the cache(not local variables).
+# The variable in the cache has to be registered with one of the `opt` macros
+macro(opt_overwrite  var_name  var_value)
+  # we do not check `if(NOT DEFINED ${var_name})` because local variables don't limit us from updating the
+  # correct variable in the cache. We rely on _DESCRIPTION and _TYPE to find if the variable was
+  # previously registered with `opt`
+  if(NOT DEFINED ${var_name}_DESCRIPTION OR NOT DEFINED ${var_name}_TYPE)
+    cberror("user-code logic error: `${var_name}` was not registered with an `opt` macro beforehand")
+  endif()
+
+  set(${var_name}  ${var_value} CACHE ${${var_name}_TYPE}  "${${var_name}_DESCRIPTION}"  FORCE)
+endmacro()

--- a/stacer-core/CMakeLists.txt
+++ b/stacer-core/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.4 FATAL_ERROR)
+project(stacer-core)
+
+include_directories(
+  "${CMAKE_CURRENT_SOURCE_DIR}"
+  "${CMAKE_CURRENT_SOURCE_DIR}/Info"
+  "${CMAKE_CURRENT_SOURCE_DIR}/Tools"
+  "${CMAKE_CURRENT_SOURCE_DIR}/Utils"
+)
+
+file(GLOB_RECURSE ${PROJECT_NAME}_srcs "${CMAKE_CURRENT_SOURCE_DIR}/**.cpp")
+
+add_definitions(-DSTACERCORE_LIBRARY)
+
+add_library(${PROJECT_NAME}  STATIC  ${${PROJECT_NAME}_srcs})
+target_link_libraries(${PROJECT_NAME} Qt5::Core)

--- a/stacer/CMakeLists.txt
+++ b/stacer/CMakeLists.txt
@@ -1,0 +1,47 @@
+cmake_minimum_required(VERSION 3.4 FATAL_ERROR)
+project(stacer)
+
+set(MANAGERS_DIR  "${CMAKE_CURRENT_SOURCE_DIR}/Managers")
+set(PAGES_DIR     "${CMAKE_CURRENT_SOURCE_DIR}/Pages")
+
+include_directories(
+  "${PROJECT_ROOT}/stacer-core"
+  "${CMAKE_CURRENT_SOURCE_DIR}"
+  "${MANAGERS_DIR}"
+  "${PAGES_DIR}/Dashboard"
+  "${PAGES_DIR}/Processes"
+  "${PAGES_DIR}/Resources"
+  "${PAGES_DIR}/Services"
+  "${PAGES_DIR}/Settings"
+  "${PAGES_DIR}/StartupApps"
+  "${PAGES_DIR}/SystemCleaner"
+  "${PAGES_DIR}/Uninstaller"
+  "${CMAKE_CURRENT_BINARY_DIR}" # Necessary for CMake 3.7 and older
+)
+
+# Sources
+file(GLOB_RECURSE ${PROJECT_NAME}_srcs         "${CMAKE_CURRENT_SOURCE_DIR}/**.cpp")
+file(GLOB_RECURSE ${PROJECT_NAME}_translations "${PROJECT_ROOT}/translations/**.ts")
+
+# Translations
+find_package(Qt5LinguistTools)
+qt5_create_translation(QM_FILES  ${PROJECT_NAME}_translations  ${${PROJECT_NAME}_srcs})
+set_directory_properties(PROPERTIES  ADDITIONAL_MAKE_CLEAN_FILES  "${QM_FILES}")
+
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTORCC ON)
+
+add_executable(${PROJECT_NAME}
+  ${${PROJECT_NAME}_srcs}
+  "${CMAKE_CURRENT_SOURCE_DIR}/static.qrc"
+  ${QM_FILES}
+)
+target_link_libraries(${PROJECT_NAME}
+  stacer-core  Qt5::Core  Qt5::Gui  Qt5::Widgets  Qt5::Charts  Qt5::Svg  Qt5::Concurrent
+)
+
+install(
+  TARGETS  ${PROJECT_NAME}
+  CONFIGURATIONS Release RelWithDebInfo MinSizeRel # Not allowing to install an unoptimized build
+  RUNTIME  DESTINATION  bin
+)


### PR DESCRIPTION
There are a few things to note here:
- This does not invalidate the `qmake` project files and builds, these can still work in parallel.
- If `ccache` or `sccache` is detected in the system, it will automatically be used
- If a faster linker is supported, it will be used(`LLD Linker` on `x86_64` with Clang, `Gold Linker` otherwise. If none supported, the default linker will be used)
- `stacer-core` is linked statically since it is a small codebase.
- Install Prefix was fixed(compared to the `qmake` version which always installs `stacer-core` in `/usr/lib`). You can use `-DCMAKE_INSTALL_PREFIX=<path>` or `make DESTDIR=<path> install`. Default prefix is `/usr/local` - that means, without passing anything, `make install` will put the binary here: `/usr/local/bin/stacer`
- `make install` will not install anything for `Debug` builds since no one should(probably by mistake) install unoptimized builds.
- Works in any IDE