### PR TITLE
Create snapcraft.yaml

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,32 @@
+name: stacer
+version: native
+summary: Linux System Optimizer and Monitoring
+description: |
+        Stacer is an open source system optimizer and Application Monitor that helps users to manage entire system with different aspects, its an all in one system utility. It's features are Dashboard, System Cleaner, Startup Apps, Services, Uninstaller and Resources.
+
+grade: devel 
+confinement: strict 
+
+apps:
+  stacer:
+     command: stacer
+     plugs: [network, home, unity7]
+                            
+parts:
+  stacer:
+    plugin: nil 
+    source: .
+    build-packages:
+        - qt-sdk
+    after:
+        - linuxdeployqt
+    install: |
+         ./deploy.sh
+         ./install.sh
+
+  linuxdeployqt:
+        plugin: qmake
+        source: https://github.com/probonopd/linuxdeployqt.git 
+        build-packages:
+             - g++
+             - libgl1-mesa-dev


### PR DESCRIPTION
Hi I am Carla from the Ubuntu Community, I am adding snapcraft.yaml file for creating snap package.
Snap packages are supported by many Linux distributions, there is a lot about them here:

https://snapcraft.io/

To use this file you have to:

installa snapcraft and snapd :
$ sudo apt install snapcraft snapd

cd to the root directory of the project

launch snapcraft
$ snapcraft

install the snap package created:
$ sudo snap install stacer_native_amd64.snap --dangerous

you can see the snap package installed with:
$ snap list

run the snap:
$ stacer

I can suggest you to use build.snapcraft.io (https://build.snapcraft.io/) to automate the delivery of the snap with a few clicks.

Carla