### PR TITLE
Lower CMake version requirements to 3.1 and enable LTO in CMake Release builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
 project(Stacer)
 
 # Adding features(build cache + faster linkers) and reasonable defaults(Debug build by default)
@@ -13,7 +13,7 @@ set(PROJECT_ROOT "${CMAKE_CURRENT_SOURCE_DIR}")
 
 # Activating MOC and searching for the Qt5 dependencies
 set(CMAKE_AUTOMOC ON)
-find_package(Qt5  COMPONENTS  Core Gui Charts Svg Concurrent  REQUIRED)
+find_package(Qt5  COMPONENTS  Core Gui Widgets Charts Svg Concurrent  REQUIRED)
 
 # Setting the minimum C++ standard and passing the Qt-specific define
 set(CMAKE_CXX_STANDARD           11)

--- a/cmake/cxxbasics/CXXBasics.cmake
+++ b/cmake/cxxbasics/CXXBasics.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
 

--- a/cmake/cxxbasics/DefaultSettings.cmake
+++ b/cmake/cxxbasics/DefaultSettings.cmake
@@ -1,6 +1,6 @@
 # This module sets reasonable defaults that probably every C/C++ CMake project should
 
-cmake_minimum_required(VERSION 3.4 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
 # Default build type "Debug"
 opt_ifndef("Build Type(Debug, Release, RelWithDebInfo, MinSizeRel)"  STRING  "Debug"  CMAKE_BUILD_TYPE)

--- a/cmake/cxxbasics/InitCXXBasics.cmake
+++ b/cmake/cxxbasics/InitCXXBasics.cmake
@@ -1,6 +1,6 @@
 ## This module defines common functions and variables that should be accessible in every module
 
-cmake_minimum_required(VERSION 3.4 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
 # Enable C and CXX by default. This allows to run some commands in script mode, or using "-C"
 enable_language(C)

--- a/cmake/cxxbasics/accelerators/UseCCache.cmake
+++ b/cmake/cxxbasics/accelerators/UseCCache.cmake
@@ -1,7 +1,7 @@
 # This module activates "ccache" support on Unix
 # This module is supposed to be used only from "UseCompilerCacheTool.cmake"
 
-cmake_minimum_required(VERSION 3.4 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
 find_program(__cxxbasics_ccache_found  ccache)
 if(__cxxbasics_ccache_found)

--- a/cmake/cxxbasics/accelerators/UseCompilerCacheTool.cmake
+++ b/cmake/cxxbasics/accelerators/UseCompilerCacheTool.cmake
@@ -1,6 +1,6 @@
 # This module activates a compiler cache
 
-cmake_minimum_required(VERSION 3.4 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
 opt_ifndef("Use a compiler cache tool, if supported"  BOOL  ON  CXXBASICS_ACTIVATE_COMPILER_CACHE)
 if(CXXBASICS_ACTIVATE_COMPILER_CACHE)

--- a/cmake/cxxbasics/accelerators/UseFasterLinkers.cmake
+++ b/cmake/cxxbasics/accelerators/UseFasterLinkers.cmake
@@ -3,7 +3,13 @@
 # The linker is handled separately per compiler, so, you can do something like this:
 # -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=clang++
 
-cmake_minimum_required(VERSION 3.4 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
+
+
+cmake_policy(PUSH)
+if(POLICY CMP0054)
+  cmake_policy(SET CMP0054 NEW)
+endif(POLICY CMP0054)
 
 opt_ifndef("Use faster linkers(LLD, GNU gold...) if supported"  BOOL  ON  CXXBASICS_USE_FASTER_LINKERS)
 if(CXXBASICS_USE_FASTER_LINKERS)
@@ -95,3 +101,5 @@ if(CXXBASICS_USE_FASTER_LINKERS)
   # Set the linker for the CXX compiler
   __cxxbasics_set_linker("${CMAKE_CXX_COMPILER}")
 endif()
+
+cmake_policy(POP)

--- a/cmake/cxxbasics/accelerators/UseSCCache.cmake
+++ b/cmake/cxxbasics/accelerators/UseSCCache.cmake
@@ -2,7 +2,7 @@
 # another compiler cache tool was not found.
 # This module is supposed to be used only from "UseCompilerCacheTool.cmake"
 
-cmake_minimum_required(VERSION 3.4 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
 find_program(__cxxbasics_sccache_found  sccache)
 if(__cxxbasics_sccache_found)

--- a/cmake/cxxbasics/compiler_detection/GetTargetArch.cmake
+++ b/cmake/cxxbasics/compiler_detection/GetTargetArch.cmake
@@ -8,7 +8,12 @@
 # IBM System z:                                                                  s390, s390x
 # SPARC:                                                                         sparcv9, sparc64, sparc
 
-cmake_minimum_required(VERSION 3.4 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
+
+cmake_policy(PUSH)
+if(POLICY CMP0054)
+  cmake_policy(SET CMP0054 NEW)
+endif(POLICY CMP0054)
 
 opt_ifndef("C compiler target architecture"    STRING  ""  CXXBASICS_C_COMPILER_TARGET_ARCH)
 opt_ifndef("CXX compiler target architecture"  STRING  ""  CXXBASICS_CXX_COMPILER_TARGET_ARCH)
@@ -159,3 +164,5 @@ if("${CXXBASICS_C_COMPILER_TARGET_ARCH}" STREQUAL ""
   __cxxbasics_define_arch(".c"    CXXBASICS_C_COMPILER_TARGET_ARCH)
   __cxxbasics_define_arch(".cxx"  CXXBASICS_CXX_COMPILER_TARGET_ARCH)
 endif()
+
+cmake_policy(POP)

--- a/cmake/cxxbasics/helpers/FnMktemp.cmake
+++ b/cmake/cxxbasics/helpers/FnMktemp.cmake
@@ -1,6 +1,6 @@
 ## This module defines helper functions to create temporary files and folders in a system-agnostic way
 
-cmake_minimum_required(VERSION 3.4 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
 opt_ifndef("CXXBasics temporary folder(uses system folder by default)"  PATH  ""  CXXBASICS_TMP_FOLDER)
 macro(__cxxbasics_mktemp_helper)

--- a/cmake/cxxbasics/helpers/MacroCustomMessages.cmake
+++ b/cmake/cxxbasics/helpers/MacroCustomMessages.cmake
@@ -1,7 +1,7 @@
 ## This module contains project-wide custom CMake messagging macros.
 ## Does not adhere to the overall style because MacroCbmessage does not sound very well nor represent all macros...
 
-cmake_minimum_required(VERSION 3.4 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
 # This does not work in Windows CMD(usually also CI)
 if(CYGWIN OR NOT CMAKE_HOST_WIN32)

--- a/cmake/cxxbasics/helpers/MacroOpt.cmake
+++ b/cmake/cxxbasics/helpers/MacroOpt.cmake
@@ -1,6 +1,6 @@
 ## This module defines helper macros to set options(cached variables)
 
-cmake_minimum_required(VERSION 3.4 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
 # @macro opt
 # Macro helper to set a cache value.

--- a/stacer-core/CMakeLists.txt
+++ b/stacer-core/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
 project(stacer-core)
 
 include_directories(

--- a/stacer/CMakeLists.txt
+++ b/stacer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
 project(stacer)
 
 set(MANAGERS_DIR  "${CMAKE_CURRENT_SOURCE_DIR}/Managers")
@@ -36,12 +36,32 @@ add_executable(${PROJECT_NAME}
   "${CMAKE_CURRENT_SOURCE_DIR}/static.qrc"
   ${QM_FILES}
 )
+
 target_link_libraries(${PROJECT_NAME}
   stacer-core  Qt5::Core  Qt5::Gui  Qt5::Widgets  Qt5::Charts  Qt5::Svg  Qt5::Concurrent
 )
+
+# Running LTO in Release builds, if the C++ compiler is GNU GCC
+if("${CMAKE_BUILD_TYPE}" STREQUAL "Release"  AND  "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+  target_compile_options(${PROJECT_NAME}  PRIVATE  "-flto")
+  list(APPEND CMAKE_EXE_LINKER_FLAGS "-flto")
+endif()
 
 install(
   TARGETS  ${PROJECT_NAME}
   CONFIGURATIONS Release RelWithDebInfo MinSizeRel # Not allowing to install an unoptimized build
   RUNTIME  DESTINATION  bin
+)
+
+install(
+  FILES           "${PROJECT_ROOT}/stacer.desktop"
+  DESTINATION     share/applications
+  CONFIGURATIONS  Release RelWithDebInfo MinSizeRel
+)
+
+install(
+  FILES           "${PROJECT_ROOT}/stacer/static/logo.png"
+  DESTINATION     share/icons
+  CONFIGURATIONS  Release RelWithDebInfo MinSizeRel
+  RENAME          stacer.png
 )


### PR DESCRIPTION
`set(CMAKE_CXX_STANDARD 11)` has effect only starting with `CMake 3.1`, so the minimum requirement was lowered to `3.1`(`CMake 3.2` available in `Ubuntu 14.04`).

This also adds LTO for Release builds, which at the moment removes only `0.1 MB` from the binary.