### PR TITLE
Show CpuModel and CpuMaxFreq properly

### DIFF
--- a/stacer-core/Info/system_info.cpp
+++ b/stacer-core/Info/system_info.cpp
@@ -18,7 +18,7 @@ SystemInfo::SystemInfo()
             QRegExp regexp("\\s+");
             QString space(" ");
             this->cpuModel = model.at(0).trimmed().replace(regexp, space);
-            this->cpuSpeed = cpuMhz.at(0).trimmed().replace(regexp, space);
+            this->cpuSpeed = cpumhz.at(0).trimmed().replace(regexp, space);
         }
     }
     else {

--- a/stacer-core/Info/system_info.cpp
+++ b/stacer-core/Info/system_info.cpp
@@ -7,14 +7,18 @@ SystemInfo::SystemInfo()
     QStringList lines = FileUtil::readListFromFile(PROC_CPUINFO)
             .filter(QRegExp("^model name"));
 
-    if (! lines.isEmpty()) {
-        QStringList model = lines.first().split(":").at(1).split("@");
+    QStringList cpuMhz = FileUtil::readListFromFile(PROC_CPUINFO)
+            .filter(QRegExp("^cpu MHz"));
 
-        if ( model.count() > 1) {
+    if (! lines.isEmpty()) {
+        QStringList model = lines.at(0).trimmed().split(":").at(1).split("@");
+        QStringList cpumhz = cpuMhz.at(0).trimmed().split(":").at(1).split("@");
+
+        if ( model.count() > 0) {
             QRegExp regexp("\\s+");
             QString space(" ");
             this->cpuModel = model.at(0).trimmed().replace(regexp, space);
-            this->cpuSpeed = model.at(1).trimmed().replace(regexp, space);
+            this->cpuSpeed = cpuMhz.at(0).trimmed().replace(regexp, space);
         }
     }
     else {

--- a/stacer/Pages/Dashboard/dashboard_page.cpp
+++ b/stacer/Pages/Dashboard/dashboard_page.cpp
@@ -103,7 +103,7 @@ void DashboardPage::systemInformationInit()
         << tr("Distribution: %1").arg(sysInfo.getDistribution())
         << tr("Kernel Release: %1").arg(sysInfo.getKernel())
         << tr("CPU Model: %1").arg(sysInfo.getCpuModel())
-        << tr("CPU Speed: %1").arg(sysInfo.getCpuSpeed())
+        << tr("CPU Speed (Mhz) : %1").arg(sysInfo.getCpuSpeed())
         << tr("CPU Core: %1").arg(sysInfo.getCpuCore());
 
     QStringListModel *systemInfoModel = new QStringListModel(infos);


### PR DESCRIPTION
Not all cpu model name have attached freq.
Most simple case is in AMD where we get something like this in /proc/cpuinfo

	model name      : AMD Ryzen 7 1800X Eight-Core Processor
	stepping        : 1
	cpu MHz         : 3594.123

The current code breaks the program and we end up with nothing in CPU Model as well as freq.
Read Model and freq in two cases to fix.