### PR TITLE
fix compile error with qt 5.11.0

### DIFF
--- a/stacer/Pages/StartupApps/startup_app_edit.cpp
+++ b/stacer/Pages/StartupApps/startup_app_edit.cpp
@@ -2,6 +2,7 @@
 #include "ui_startup_app_edit.h"
 #include "utilities.h"
 #include <QDebug>
+#include <QStyle>
 
 StartupAppEdit::~StartupAppEdit()
 {

--- a/stacer/app.cpp
+++ b/stacer/app.cpp
@@ -1,6 +1,7 @@
 #include "app.h"
 #include "ui_app.h"
 #include "utilities.h"
+#include <QStyle>
 
 App::~App()
 {


### PR DESCRIPTION
added missing includes where needed.
 error: incomplete type 'QStyle' used in nested name specifier