### PR TITLE
FIX for the Startup Apps page to handle when the system is configured…

### DIFF
--- a/stacer/Pages/StartupApps/startup_apps_page.h
+++ b/stacer/Pages/StartupApps/startup_apps_page.h
@@ -40,6 +40,8 @@ private:
 
     QFileSystemWatcher mFileSystemWatcher;
     QString mAutostartPath;
+
+    bool checkIfDisabled(const QString& as_path);
 };
 
 #endif // STARTUPAPPSPAGE_H


### PR DESCRIPTION
… with startup apps disabled.

On my system  I would get the following message when executing Stacer from a terminal:
```
inotify_add_watch(/home/malexa/.config/autostart/) failed: (Not a directory)
```

Upon investigating the code & my configuration, I noticed that Stacer **_does not_** check if autostart is a file instead of a directory. Here, are the contents of the _/home/malexa/.config/autostart_ file:
```
X-GNOME-Autostart-enabled=false
```
My patch simply disables autostart editing functionality in Stacer until the user, if he/she ever, deletes the autostart file containing the disable declaration. If it's deleted, Stacer will perform the same as prior to this patch.