### PR TITLE
Various memory leak fixes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 Stacer.pro.*
+stacer/stacer.pro.user
+stacer-core/stacer-core.pro.user
 dist/
 build/
 #*.AppImage

--- a/stacer-core/Utils/command_util.cpp
+++ b/stacer-core/Utils/command_util.cpp
@@ -4,6 +4,7 @@
 #include <QTextStream>
 #include <QStandardPaths>
 #include <QDebug>
+#include <utility>
 
 QString CommandUtil::sudoExec(const QString &cmd, QStringList args, QByteArray data)
 {
@@ -44,7 +45,10 @@ QString CommandUtil::exec(const QString &cmd, QStringList args, QByteArray data)
     if (process->error() != QProcess::UnknownError)
         throw err;
 
-    return stdOut.readAll().trimmed();
+    QString&& ret = stdOut.readAll().trimmed();
+    delete process;
+
+    return std::move(ret);
 }
 
 bool CommandUtil::isExecutable(const QString &cmd)

--- a/stacer/Pages/Processes/processes_page.cpp
+++ b/stacer/Pages/Processes/processes_page.cpp
@@ -95,6 +95,7 @@ void ProcessesPage::loadProcesses()
 {
     QModelIndexList selecteds = ui->tableProcess->selectionModel()->selectedRows();
 
+    cleanupItemModel(&mItemModel, mItemModel->rowCount(), mItemModel->columnCount());
     mItemModel->removeRows(0, mItemModel->rowCount());
 
     im->updateProcesses();
@@ -237,5 +238,31 @@ void ProcessesPage::on_tableProcess_customContextMenuRequested(const QPoint &pos
 
     if (action) {
         ui->tableProcess->horizontalHeader()->setSectionHidden(action->data().toInt(), ! action->isChecked());
+    }
+}
+
+void ProcessesPage::cleanupItemModel(QStandardItemModel **model, int model_rows, int model_cols)
+{
+    QStandardItemModel *mod = *model;
+    QStandardItem *itm = nullptr;
+    QModelIndex qmi;
+
+
+    if (model_rows < 1)
+        return;
+
+    for (int i=0; i <= model_cols; i++)
+    {
+        for (int j=0; j < model_rows; j++)
+        {
+            // create an index
+            qmi = mod->sibling(j, i, QModelIndex());
+            // crap, just give up
+            if (!qmi.isValid())
+                continue;
+            // clear the data
+            itm = mod->item(j, i);
+            delete itm;
+        }
     }
 }

--- a/stacer/Pages/Processes/processes_page.h
+++ b/stacer/Pages/Processes/processes_page.h
@@ -12,6 +12,8 @@
 
 #include "Managers/info_manager.h"
 
+#define STACER_DATA 1
+
 namespace Ui {
     class ProcessesPage;
 }
@@ -44,6 +46,8 @@ private:
     QMenu mHeaderMenu;
     QTimer *mTimer;
     InfoManager *im;
+
+    void cleanupItemModel(QStandardItemModel **model, int model_rows, int model_cols);
 };
 
 #endif // PROCESSESPAGE_H

--- a/stacer/Pages/SystemCleaner/system_cleaner_page.cpp
+++ b/stacer/Pages/SystemCleaner/system_cleaner_page.cpp
@@ -3,6 +3,8 @@
 
 SystemCleanerPage::~SystemCleanerPage()
 {
+    this->invalidateTree(ui->treeWidgetScanResult);
+
     delete ui;
 }
 
@@ -45,6 +47,9 @@ void SystemCleanerPage::init()
         mLoadingMovie_2->start();
         ui->lblLoadingCleaner->hide();
     });
+
+    // memory management :o
+    connect(this, SIGNAL(treeInvalidated(QTreeWidget*)), this, SLOT(invalidateTree(QTreeWidget*)));
 }
 
 void SystemCleanerPage::addTreeRoot(const CleanCategories &cat, const QString &title, const QFileInfoList &infos, bool noChild)
@@ -312,6 +317,8 @@ void SystemCleanerPage::on_btnBackToCategories_clicked()
     ui->treeWidgetScanResult->clear();
     ui->stackedWidget->setCurrentIndex(0);
     ui->checkSelectAllSystemScan->setChecked(false);
+
+    emit treeInvalidated(ui->treeWidgetScanResult);
 }
 
 void SystemCleanerPage::on_checkSelectAllSystemScan_clicked(bool checked)
@@ -321,4 +328,17 @@ void SystemCleanerPage::on_checkSelectAllSystemScan_clicked(bool checked)
     ui->checkCrashReports->setChecked(checked);
     ui->checkPackageCache->setChecked(checked);
     ui->checkTrash->setChecked(checked);
+}
+
+void SystemCleanerPage::invalidateTree(QTreeWidget *tree)
+{
+    auto items = ui->treeWidgetScanResult->findItems(QString("*"), Qt::MatchWrap | Qt::MatchWildcard | Qt::MatchRecursive);
+
+    if (!ui->treeWidgetScanResult->children().empty() || !items.empty())
+    {
+        for (auto a = items.begin(); a != items.end(); ++a)
+        {
+            delete *a;
+        }
+    }
 }

--- a/stacer/Pages/SystemCleaner/system_cleaner_page.h
+++ b/stacer/Pages/SystemCleaner/system_cleaner_page.h
@@ -34,6 +34,9 @@ public:
     explicit SystemCleanerPage(QWidget *parent = 0);
     ~SystemCleanerPage();
 
+signals:
+    void treeInvalidated(QTreeWidget *tree);
+
 private slots:
     void addTreeRoot(const CleanCategories &cat, const QString &title, const QFileInfoList &infos, bool noChild = false);
     void addTreeChild(const CleanCategories &cat, const QString &text, const quint64 &size);
@@ -49,6 +52,8 @@ private slots:
     bool cleanValid();
 
     void on_checkSelectAllSystemScan_clicked(bool checked);
+
+    void invalidateTree(QTreeWidget *tree);
 
 private:
     void init();


### PR DESCRIPTION
**REF:** #236 and #229 
---
Various memory leaks that were found thanks to [valgrind log](https://github.com/oguzhaninan/Stacer/files/2609401/stacer.log) courtesy of @FireFoxII .

Running:
```
valgrind --read-var-info=yes --read-inline-info=yes --leak-check=full --log-file=new-valgrind.xml output/stacer
```
The resulting log file is **_less polluted_** by errors originating from Stacer.
