### PR TITLE
HOTFIX for Critical Issue #252.

### DIFF
--- a/stacer-core/Types/Applications/broken_app.cpp
+++ b/stacer-core/Types/Applications/broken_app.cpp
@@ -98,7 +98,7 @@ void BrokenApp::run()
             return;
         }
 
-        QString cmd_s = QString("grep \"^Exec\" %1 | tail -1")
+        QString cmd_s = QString("grep \"^Exec\" \'%1\' | tail -1")
                 .arg(m_deskfile.second->file_path);
         PosixCmd cmdcmd(cmd_s);
 


### PR DESCRIPTION
**REF:** #252 
---
##### This Hotfix closes the above reference issue.
###### More information:
<p>Users of the Linux Steam client will experience this bug, as it caused grep to fail with filenames that contained spaces. Non-gamers would probably never have this issue; Steam's games are the only *.desktop files that I've seen with whitespace yielding names. :face_with_head_bandage: </p>