### PR TITLE
Change Fedora installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,12 @@
 3. Launch Stacer using the installed `stacer` command.
 
 ### Fedora
+1. Download `stacer_1.1.0_amd64.rpm` from the [Stacer releases page](https://github.com/oguzhaninan/Stacer/releases).
+2. Run `sudo rpm --install stacer*.rpm --nodeps --force` on the downloaded package.
+3. Launch Stacer using the installed `stacer` command.
 
-1. Install via DNF: `sudo dnf install stacer`
+### Fedora (with DNF)
+1. Run: `sudo dnf install stacer`
 2. Launch Stacer using the installed `stacer` command.
 
 ## Build from source with CMake (Qt Version Qt 5.x)

--- a/README.md
+++ b/README.md
@@ -64,11 +64,10 @@
 2. Run `sudo dpkg -i stacer*.deb` on the downloaded package.
 3. Launch Stacer using the installed `stacer` command.
 
-### Fedora x64
+### Fedora
 
-1. Download `stacer_1.1.0_amd64.rpm` from the [Stacer releases page](https://github.com/oguzhaninan/Stacer/releases).
-2. Run `sudo rpm --install stacer*.rpm --nodeps --force` on the downloaded package.
-3. Launch Stacer using the installed `stacer` command.
+1. Install via DNF: `sudo dnf install stacer`
+2. Launch Stacer using the installed `stacer` command.
 
 ## Build from source with CMake (Qt Version Qt 5.x)
 1. mkdir build && cd build


### PR DESCRIPTION
Stacer in official repos now and built for [all six](https://koji.fedoraproject.org/koji/taskinfo?taskID=35351213) architectures and all actual Fedora versions.

On QA [now](https://bodhi.fedoraproject.org/updates/FEDORA-2019-d42de0a34c).