### PR TITLE
#345 Add cpu speed to non intel processors

### DIFF
--- a/stacer-core/Info/system_info.h
+++ b/stacer-core/Info/system_info.h
@@ -6,7 +6,7 @@
 #include "Utils/command_util.h"
 #include "Info/cpu_info.h"
 
-#define PROC_CPUINFO "/proc/cpuinfo"
+#define LSCPU_COMMAND "LANG=nl_NL.UTF-8 lscpu"
 
 #include "stacer-core_global.h"
 


### PR DESCRIPTION
Now the field CPU Speed shows for every CPU manufacturer, by using lscpu command.

![Captura de tela de 2020-01-11 16-27-08](https://user-images.githubusercontent.com/37881981/72209662-3f963e00-348f-11ea-8583-fa86b04ec88a.png)
