### PR TITLE
#346 Add current cpu clock to main page

### DIFF
--- a/stacer-core/Info/cpu_info.cpp
+++ b/stacer-core/Info/cpu_info.cpp
@@ -1,5 +1,7 @@
 #include "cpu_info.h"
 
+#include "command_util.h"
+
 quint8 CpuInfo::getCpuCoreCount() const
 {
     static quint8 count = 0;
@@ -28,6 +30,25 @@ QList<double> CpuInfo::getLoadAvgs() const
     }
 
     return avgs;
+}
+
+double CpuInfo::getAvgClock() const
+{
+    QStringList lines = CommandUtil::exec("bash",{"-c", LSCPU_COMMAND}).split('\n');
+    QString clockMHz = lines.filter(QRegExp("^CPU MHz")).first().split(":").last();
+    return clockMHz.toDouble();
+}
+
+QList<double> CpuInfo::getClocks() const
+{
+    QStringList lines = FileUtil::readListFromFile(PROC_CPUINFO)
+            .filter(QRegExp("^cpu MHz"));
+
+    QList<double> clocks;
+    for(auto line: lines){
+        clocks.push_back(line.split(":").last().toDouble());
+    }
+    return clocks;
 }
 
 QList<int> CpuInfo::getCpuPercents() const

--- a/stacer-core/Info/cpu_info.h
+++ b/stacer-core/Info/cpu_info.h
@@ -7,6 +7,7 @@
 #include "Utils/file_util.h"
 
 #define PROC_CPUINFO "/proc/cpuinfo"
+#define LSCPU_COMMAND "LANG=nl_NL.UTF-8 lscpu"
 #define PROC_LOADAVG "/proc/loadavg"
 #define PROC_STAT    "/proc/stat"
 
@@ -18,6 +19,8 @@ public:
     quint8 getCpuCoreCount() const;
     QList<int> getCpuPercents() const;
     QList<double> getLoadAvgs() const;
+    double getAvgClock() const;
+    QList<double> getClocks() const;
 
 private:
     int getCpuPercent(const QList<double> &cpuTimes, const int &processor = 0) const;

--- a/stacer/Managers/info_manager.cpp
+++ b/stacer/Managers/info_manager.cpp
@@ -44,6 +44,11 @@ QList<double> InfoManager::getCpuLoadAvgs() const
     return ci.getLoadAvgs();
 }
 
+double InfoManager::getCpuClock() const
+{
+    return ci.getAvgClock();
+}
+
 /*
  * Memory Provider
  */

--- a/stacer/Managers/info_manager.h
+++ b/stacer/Managers/info_manager.h
@@ -18,6 +18,7 @@ public:
     quint8 getCpuCoreCount() const;
     QList<int> getCpuPercents() const;
     QList<double> getCpuLoadAvgs() const;
+    double getCpuClock() const;
 
     quint64 getSwapUsed() const;
     quint64 getSwapTotal() const;

--- a/stacer/Pages/Dashboard/dashboard_page.cpp
+++ b/stacer/Pages/Dashboard/dashboard_page.cpp
@@ -127,6 +127,7 @@ void DashboardPage::systemInformationInit()
 void DashboardPage::updateCpuBar()
 {
     int cpuUsedPercent = im->getCpuPercents().at(0);
+    double cpuCurrentClockGHz = im->getCpuClock()/1000.0;
 
     // alert message
     int cpuAlerPercent = mSettingManager->getCpuAlertPercent();
@@ -142,7 +143,7 @@ void DashboardPage::updateCpuBar()
         }
     }
 
-    mCpuBar->setValue(cpuUsedPercent, QString("%1%").arg(cpuUsedPercent));
+    mCpuBar->setValue(cpuUsedPercent, QString("%1 GHz\n%2%").arg(cpuCurrentClockGHz, 0, 'f', 2).arg(cpuUsedPercent));
 }
 
 void DashboardPage::updateMemoryBar()


### PR DESCRIPTION
Now the main page also display current cpu average clock.

![stacerClock](https://user-images.githubusercontent.com/37881981/72209762-c13a9b80-3490-11ea-83ca-74ce7d08e33d.gif)
