### PR TITLE
Introduce CpuInfo::getCpuPhysicalCoreCount().

### DIFF
--- a/stacer-core/Info/cpu_info.cpp
+++ b/stacer-core/Info/cpu_info.cpp
@@ -2,7 +2,40 @@
 
 #include "command_util.h"
 
-quint8 CpuInfo::getCpuCoreCount() const
+int CpuInfo::getCpuPhysicalCoreCount() const
+{
+    static int count = 0;
+
+    if (! count) {
+        QStringList cpuinfo = FileUtil::readListFromFile(PROC_CPUINFO);
+
+        if (! cpuinfo.isEmpty()) {
+	    QSet<QPair<int, int> > physicalCoreSet;
+	    int physical = 0;
+	    int core = 0;
+	    for (int i = 0; i < cpuinfo.size(); ++i) {
+	        const QString& line = cpuinfo[i];
+		if (line.startsWith("physical id")) {
+		    QStringList fields = line.split(": ");
+		    if (fields.size() > 1)
+		        physical = fields[1].toInt();
+		}
+		if (line.startsWith("core id")) {
+		    QStringList fields = line.split(": ");
+		    if (fields.size() > 1)
+		        core = fields[1].toInt();
+		    // We assume core id appears after physical id.
+		    physicalCoreSet.insert(qMakePair(physical, core));
+		}
+	    }
+	    count = physicalCoreSet.size();
+	}
+    }
+
+    return count;
+}
+
+int CpuInfo::getCpuCoreCount() const
 {
     static quint8 count = 0;
 

--- a/stacer-core/Info/cpu_info.h
+++ b/stacer-core/Info/cpu_info.h
@@ -16,7 +16,8 @@
 class STACERCORESHARED_EXPORT CpuInfo
 {
 public:
-    quint8 getCpuCoreCount() const;
+    int getCpuPhysicalCoreCount() const;
+    int getCpuCoreCount() const;
     QList<int> getCpuPercents() const;
     QList<double> getLoadAvgs() const;
     double getAvgClock() const;

--- a/stacer-core/Info/system_info.cpp
+++ b/stacer-core/Info/system_info.cpp
@@ -32,7 +32,7 @@ SystemInfo::SystemInfo()
     }
 
     CpuInfo ci;
-    this->cpuCore = QString::number(ci.getCpuCoreCount());
+    this->cpuCore = QString::number(ci.getCpuPhysicalCoreCount());
 
     // get username
     QString name = qgetenv("USER");

--- a/stacer/Managers/info_manager.cpp
+++ b/stacer/Managers/info_manager.cpp
@@ -29,7 +29,7 @@ QStringList InfoManager::getGroupList() const
 /*
  * CPU Provider
  */
-quint8 InfoManager::getCpuCoreCount() const
+int InfoManager::getCpuCoreCount() const
 {
     return ci.getCpuCoreCount();
 }

--- a/stacer/Managers/info_manager.h
+++ b/stacer/Managers/info_manager.h
@@ -15,7 +15,7 @@ class InfoManager
 public:
     static InfoManager *ins();
 
-    quint8 getCpuCoreCount() const;
+    int getCpuCoreCount() const;
     QList<int> getCpuPercents() const;
     QList<double> getCpuLoadAvgs() const;
     double getCpuClock() const;


### PR DESCRIPTION
Hyper-threading, when enabled, makes the number of processors two
times the number of physical cores.

Member function getCpuPhysicalCoreCount() is introduced to get the
number of physical cores and it is used in "Dashboard" but not in
"Resources".

The way it works is that it counts the number of unique physical
id, core id pair in /proc/cpuinfo.