### PR TITLE
Fix Disk read Write data

### DIFF
--- a/stacer-core/Info/disk_info.cpp
+++ b/stacer-core/Info/disk_info.cpp
@@ -8,13 +8,14 @@ QList<Disk*> DiskInfo::getDisks() const
 
 void DiskInfo::updateDiskInfo()
 {
+    qDeleteAll(disks);
     disks.clear();
 
     QList<QStorageInfo> storageInfoList = QStorageInfo::mountedVolumes();
 
     for(const QStorageInfo &info: storageInfoList) {
         if (info.isValid()) {
-            Disk *disk = new Disk;
+            Disk *disk = new Disk();
             disk->name = info.displayName();
             disk->device = info.device();
             disk->size = info.bytesTotal();
@@ -35,6 +36,11 @@ QList<QString> DiskInfo::devices()
     }
 
     return set.toList();
+}
+
+DiskInfo::~DiskInfo()
+{
+    qDeleteAll(disks);
 }
 
 QList<QString> DiskInfo::fileSystemTypes()

--- a/stacer-core/Info/disk_info.h
+++ b/stacer-core/Info/disk_info.h
@@ -20,6 +20,7 @@ public:
     QStringList getDiskNames() const;
     QList<QString> fileSystemTypes();
     QList<QString> devices();
+    ~DiskInfo();
 
 private:
     QList<Disk*> disks;

--- a/stacer-core/Info/disk_info.h
+++ b/stacer-core/Info/disk_info.h
@@ -25,7 +25,7 @@ private:
     QList<Disk*> disks;
 };
 
-struct Disk {	
+struct Disk {
     QString name;
     QString device;
     QString fileSystemType;

--- a/stacer-core/Info/disk_info.h
+++ b/stacer-core/Info/disk_info.h
@@ -17,16 +17,16 @@ public:
     QList<Disk*> getDisks() const;
     void updateDiskInfo();
     QList<quint64> getDiskIO() const;
-    QString getDiskName() const;
+    QStringList getDiskNames() const;
     QList<QString> fileSystemTypes();
     QList<QString> devices();
-    ~DiskInfo();
 
 private:
     QList<Disk*> disks;
 };
 
-struct Disk {
+class Disk {
+public:
     QString name;
     QString device;
     QString fileSystemType;

--- a/stacer-core/Info/disk_info.h
+++ b/stacer-core/Info/disk_info.h
@@ -25,8 +25,7 @@ private:
     QList<Disk*> disks;
 };
 
-class Disk {
-public:
+struct Disk {	
     QString name;
     QString device;
     QString fileSystemType;


### PR DESCRIPTION
Make sure that not only the first disk IO is reported but the sum of all disk IO.
For example: If the computer has devices sda and sdb, add the IO numbers of both devices together.
Previously only the first device that was found was included in the returned data.