### PR TITLE
Change term to plural

### DIFF
--- a/translations/stacer_en.ts
+++ b/translations/stacer_en.ts
@@ -371,7 +371,7 @@
     </message>
     <message>
         <location filename="../stacer/Pages/Dashboard/dashboard_page.cpp" line="116"/>
-        <source>CPU Core: %1</source>
+        <source>CPU Cores: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>


### PR DESCRIPTION
This is just something totally negligible.

The dashboard says **CPU Core** inside the system information. Since this is about the number of cores and not the core itself, the plural (**CPU Cores**) would be appropriate here.