### PR TITLE
remove only files not directory

### DIFF
--- a/stacer-core/Info/system_info.cpp
+++ b/stacer-core/Info/system_info.cpp
@@ -135,7 +135,8 @@ QFileInfoList SystemInfo::getAppLogs() const
 {
     QDir logs("/var/log");
 
-    return logs.entryInfoList(QDir::Files | QDir::Dirs | QDir::NoDotAndDotDot);
+    //remove only files not directory ex. apache2 (log directory)
+    return logs.entryInfoList(QDir::Files | QDir::NoDotAndDotDot);
 }
 
 QFileInfoList SystemInfo::getAppCaches() const


### PR DESCRIPTION
Remove only files not directory : Only remove log files if remove directory service like apache2 won't start.
Old Code : 
return logs.entryInfoList(QDir::Files | QDir::Dirs | QDir::NoDotAndDotDot);
New Code:
return logs.entryInfoList(QDir::Files | QDir::NoDotAndDotDot);
While scanning scan only files not directory to retrive.