### PR TITLE
Can Now Double-Click Stacer's System Tray Icon to Quickly Pop It Up!

### DIFF
--- a/stacer/app.cpp
+++ b/stacer/app.cpp
@@ -150,7 +150,7 @@ void App::createTrayActions()
         connect(mTrayIcon, &QSystemTrayIcon::activated, this, [=](QSystemTrayIcon::ActivationReason){
             setVisible(true);
             activateWindow();	
-        }));
+        });
 
         mTrayMenu->addAction(action);
     }

--- a/stacer/app.cpp
+++ b/stacer/app.cpp
@@ -147,6 +147,11 @@ void App::createTrayActions()
         connect(action, &QAction::triggered, [=] {
             clickSidebarButton(toolTip, true);
         });
+        connect(mTrayIcon, &QSystemTrayIcon::activated, this, [=](QSystemTrayIcon::ActivationReason){
+            setVisible(true);
+            activateWindow();	
+        }));
+
         mTrayMenu->addAction(action);
     }
 


### PR DESCRIPTION
When Stacer is closed into the system tray it has always been inconvenient (ie. requires multiple clicks) to restore Stacer's window.  

For example, a user has to click its system tray to reveal the menu and then click again on one of the menu choices to finally bring up the Stacer window  

This "fix" gives the user an extra power -- to just double-click Stacer's system tray icon to bring up the last window area s/he was on.  All of Stacer's original functions remain the same; the user just now has the extra ability to double-click.