### PR TITLE
Fix grammatical errors.

### DIFF
--- a/stacer/Pages/Dashboard/dashboard_page.ui
+++ b/stacer/Pages/Dashboard/dashboard_page.ui
@@ -227,7 +227,7 @@
       <item alignment="Qt::AlignLeft|Qt::AlignVCenter">
        <widget class="QLabel" name="lblUpdateBarText">
         <property name="text">
-         <string>There are update currently available.</string>
+         <string>There are updates currently available.</string>
         </property>
        </widget>
       </item>

--- a/stacer/feedback.cpp
+++ b/stacer/feedback.cpp
@@ -76,7 +76,7 @@ void Feedback::on_btnSend_clicked()
 
                 if (response.value("success").toBool()) {
                     emit clearInputs();
-                    emit setErrorMessageS(tr("<font color='#2ecc71'>Your Feedback has been successfully sended.</font>"));
+                    emit setErrorMessageS(tr("<font color='#2ecc71'>Your Feedback has been successfully sent.</font>"));
                 } else {
                     emit setErrorMessageS(tr("Something went wrong, try again !"));
                 }

--- a/stacer/feedback.ui
+++ b/stacer/feedback.ui
@@ -75,7 +75,7 @@
       <string notr="true">dialog-title</string>
      </property>
      <property name="text">
-      <string>Send a Feedback</string>
+      <string>Send Feedback</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignCenter</set>

--- a/translations/stacer_ar.ts
+++ b/translations/stacer_ar.ts
@@ -306,7 +306,7 @@
     </message>
     <message>
         <location filename="../stacer/Pages/Dashboard/dashboard_page.ui" line="230"/>
-        <source>There are update currently available.</source>
+        <source>There are updates currently available.</source>
         <translation>هنالك تحديثات موجودة حالياً.</translation>
     </message>
     <message>
@@ -440,7 +440,7 @@
     </message>
     <message>
         <location filename="../stacer/feedback.ui" line="104"/>
-        <source>Send a Feedback</source>
+        <source>Send Feedback</source>
         <translation type="unfinished">إرسال المراجعة</translation>
     </message>
     <message>
@@ -460,7 +460,7 @@
     </message>
     <message>
         <location filename="../stacer/feedback.cpp" line="79"/>
-        <source>&lt;font color=&apos;#2ecc71&apos;&gt;Your Feedback has been successfully sended.&lt;/font&gt;</source>
+        <source>&lt;font color=&apos;#2ecc71&apos;&gt;Your Feedback has been successfully sent.&lt;/font&gt;</source>
         <translation type="unfinished">&lt;font color=&apos;#2ecc71&apos;&gt;تم إرسال مراجعتك بنجاح.&lt;/font&gt;</translation>
     </message>
     <message>

--- a/translations/stacer_ca-es.ts
+++ b/translations/stacer_ca-es.ts
@@ -306,7 +306,7 @@
     </message>
     <message>
         <location filename="../stacer/Pages/Dashboard/dashboard_page.ui" line="230"/>
-        <source>There are update currently available.</source>
+        <source>There are updates currently available.</source>
         <translation>Hi ha actualitzacions disponibles.</translation>
     </message>
     <message>
@@ -440,7 +440,7 @@
     </message>
     <message>
         <location filename="../stacer/feedback.ui" line="104"/>
-        <source>Send a Feedback</source>
+        <source>Send Feedback</source>
         <translation>Envia comentaris</translation>
     </message>
     <message>
@@ -460,7 +460,7 @@
     </message>
     <message>
         <location filename="../stacer/feedback.cpp" line="79"/>
-        <source>&lt;font color=&apos;#2ecc71&apos;&gt;Your Feedback has been successfully sended.&lt;/font&gt;</source>
+        <source>&lt;font color=&apos;#2ecc71&apos;&gt;Your Feedback has been successfully sent.&lt;/font&gt;</source>
         <translation>&lt;font color=&apos;#2ecc71&apos;&gt;Els vostres comentaris s&apos;han enviat amb èxit.&lt;/font&gt;</translation>
     </message>
     <message>

--- a/translations/stacer_cs.ts
+++ b/translations/stacer_cs.ts
@@ -318,7 +318,7 @@
     </message>
     <message>
         <location filename="../stacer/Pages/Dashboard/dashboard_page.ui" line="230"/>
-        <source>There are update currently available.</source>
+        <source>There are updates currently available.</source>
         <translation>K disposici je aktualizace</translation>
     </message>
     <message>
@@ -452,7 +452,7 @@
     </message>
     <message>
         <location filename="../stacer/feedback.ui" line="104"/>
-        <source>Send a Feedback</source>
+        <source>Send Feedback</source>
         <translation>Odeslat zpětnou vazbu</translation>
     </message>
     <message>
@@ -472,7 +472,7 @@
     </message>
     <message>
         <location filename="../stacer/feedback.cpp" line="79"/>
-        <source>&lt;font color=&apos;#2ecc71&apos;&gt;Your Feedback has been successfully sended.&lt;/font&gt;</source>
+        <source>&lt;font color=&apos;#2ecc71&apos;&gt;Your Feedback has been successfully sent.&lt;/font&gt;</source>
         <translation>&lt;font color=&apos;#2ecc71&apos;&gt;Vaše zpětná vazba byla úspěšně odeslána.&lt;/font&gt;</translation>
     </message>
     <message>

--- a/translations/stacer_de.ts
+++ b/translations/stacer_de.ts
@@ -318,7 +318,7 @@
     </message>
     <message>
         <location filename="../stacer/Pages/Dashboard/dashboard_page.ui" line="230"/>
-        <source>There are update currently available.</source>
+        <source>There are updates currently available.</source>
         <translation>Es stehen Aktualisierungen zur Verfügung.</translation>
     </message>
     <message>
@@ -452,7 +452,7 @@
     </message>
     <message>
         <location filename="../stacer/feedback.ui" line="104"/>
-        <source>Send a Feedback</source>
+        <source>Send Feedback</source>
         <translation>Feedback senden</translation>
     </message>
     <message>
@@ -472,7 +472,7 @@
     </message>
     <message>
         <location filename="../stacer/feedback.cpp" line="79"/>
-        <source>&lt;font color=&apos;#2ecc71&apos;&gt;Your Feedback has been successfully sended.&lt;/font&gt;</source>
+        <source>&lt;font color=&apos;#2ecc71&apos;&gt;Your Feedback has been successfully sent.&lt;/font&gt;</source>
         <translation>&lt;font color=&apos;#2ecc71&apos;&gt;Dein Feedback wurde erfolgreich versandt.&lt;/font&gt;</translation>
     </message>
     <message>

--- a/translations/stacer_en.ts
+++ b/translations/stacer_en.ts
@@ -306,7 +306,7 @@
     </message>
     <message>
         <location filename="../stacer/Pages/Dashboard/dashboard_page.ui" line="230"/>
-        <source>There are update currently available.</source>
+        <source>There are updates currently available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -440,7 +440,7 @@
     </message>
     <message>
         <location filename="../stacer/feedback.ui" line="104"/>
-        <source>Send a Feedback</source>
+        <source>Send Feedback</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -460,7 +460,7 @@
     </message>
     <message>
         <location filename="../stacer/feedback.cpp" line="79"/>
-        <source>&lt;font color=&apos;#2ecc71&apos;&gt;Your Feedback has been successfully sended.&lt;/font&gt;</source>
+        <source>&lt;font color=&apos;#2ecc71&apos;&gt;Your Feedback has been successfully sent.&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/stacer_es.ts
+++ b/translations/stacer_es.ts
@@ -306,7 +306,7 @@
     </message>
     <message>
         <location filename="../stacer/Pages/Dashboard/dashboard_page.ui" line="230"/>
-        <source>There are update currently available.</source>
+        <source>There are updates currently available.</source>
         <translation>Actualmente hay actualizaciones disponibles.</translation>
     </message>
     <message>
@@ -440,7 +440,7 @@
     </message>
     <message>
         <location filename="../stacer/feedback.ui" line="104"/>
-        <source>Send a Feedback</source>
+        <source>Send Feedback</source>
         <translation>Envía un comentario</translation>
     </message>
     <message>
@@ -460,7 +460,7 @@
     </message>
     <message>
         <location filename="../stacer/feedback.cpp" line="79"/>
-        <source>&lt;font color=&apos;#2ecc71&apos;&gt;Your Feedback has been successfully sended.&lt;/font&gt;</source>
+        <source>&lt;font color=&apos;#2ecc71&apos;&gt;Your Feedback has been successfully sent.&lt;/font&gt;</source>
         <translation>&lt;font color=&apos;#2ecc71&apos;&gt;Tu comentario ha sido enviado correctamente.&lt;/font&gt;</translation>
     </message>
     <message>

--- a/translations/stacer_fr.ts
+++ b/translations/stacer_fr.ts
@@ -306,7 +306,7 @@
     </message>
     <message>
         <location filename="../stacer/Pages/Dashboard/dashboard_page.ui" line="230"/>
-        <source>There are update currently available.</source>
+        <source>There are updates currently available.</source>
         <translation>Il existe actuellement des mises à jour disponibles.</translation>
     </message>
     <message>
@@ -440,7 +440,7 @@
     </message>
     <message>
         <location filename="../stacer/feedback.ui" line="104"/>
-        <source>Send a Feedback</source>
+        <source>Send Feedback</source>
         <translation>Envoyer un commentaire</translation>
     </message>
     <message>
@@ -460,7 +460,7 @@
     </message>
     <message>
         <location filename="../stacer/feedback.cpp" line="79"/>
-        <source>&lt;font color=&apos;#2ecc71&apos;&gt;Your Feedback has been successfully sended.&lt;/font&gt;</source>
+        <source>&lt;font color=&apos;#2ecc71&apos;&gt;Your Feedback has been successfully sent.&lt;/font&gt;</source>
         <translation>&lt;font color=&apos;#2ecc71&apos;&gt;Votre commentaire a été envoyé avec succès.&lt;/font&gt;</translation>
     </message>
     <message>

--- a/translations/stacer_gl.ts
+++ b/translations/stacer_gl.ts
@@ -306,7 +306,7 @@
     </message>
     <message>
         <location filename="../stacer/Pages/Dashboard/dashboard_page.ui" line="230"/>
-        <source>There are update currently available.</source>
+        <source>There are updates currently available.</source>
         <translation type="unfinished">Existen actualizacións dispoñíbeis.</translation>
     </message>
     <message>
@@ -440,7 +440,7 @@
     </message>
     <message>
         <location filename="../stacer/feedback.ui" line="104"/>
-        <source>Send a Feedback</source>
+        <source>Send Feedback</source>
         <translation type="unfinished">Enviar unha opinión</translation>
     </message>
     <message>
@@ -460,7 +460,7 @@
     </message>
     <message>
         <location filename="../stacer/feedback.cpp" line="79"/>
-        <source>&lt;font color=&apos;#2ecc71&apos;&gt;Your Feedback has been successfully sended.&lt;/font&gt;</source>
+        <source>&lt;font color=&apos;#2ecc71&apos;&gt;Your Feedback has been successfully sent.&lt;/font&gt;</source>
         <translation type="unfinished">&lt;font color=&apos;#2ecc71&apos;&gt;A súa opinión foi enviada correctamente.&lt;/font&gt;</translation>
     </message>
     <message>

--- a/translations/stacer_hi.ts
+++ b/translations/stacer_hi.ts
@@ -306,7 +306,7 @@
     </message>
     <message>
         <location filename="../stacer/Pages/Dashboard/dashboard_page.ui" line="230"/>
-        <source>There are update currently available.</source>
+        <source>There are updates currently available.</source>
         <translation>वर्तमान में उपलब्ध अपडेट उपलब्ध हैं.</translation>
     </message>
     <message>
@@ -440,7 +440,7 @@
     </message>
     <message>
         <location filename="../stacer/feedback.ui" line="104"/>
-        <source>Send a Feedback</source>
+        <source>Send Feedback</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -460,7 +460,7 @@
     </message>
     <message>
         <location filename="../stacer/feedback.cpp" line="79"/>
-        <source>&lt;font color=&apos;#2ecc71&apos;&gt;Your Feedback has been successfully sended.&lt;/font&gt;</source>
+        <source>&lt;font color=&apos;#2ecc71&apos;&gt;Your Feedback has been successfully sent.&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/stacer_hu.ts
+++ b/translations/stacer_hu.ts
@@ -306,7 +306,7 @@
     </message>
     <message>
         <location filename="../stacer/Pages/Dashboard/dashboard_page.ui" line="230"/>
-        <source>There are update currently available.</source>
+        <source>There are updates currently available.</source>
         <translation>Új frissítés érhető el.</translation>
     </message>
     <message>
@@ -440,7 +440,7 @@
     </message>
     <message>
         <location filename="../stacer/feedback.ui" line="104"/>
-        <source>Send a Feedback</source>
+        <source>Send Feedback</source>
         <translation>Visszajelzés Küldése</translation>
     </message>
     <message>
@@ -460,7 +460,7 @@
     </message>
     <message>
         <location filename="../stacer/feedback.cpp" line="79"/>
-        <source>&lt;font color=&apos;#2ecc71&apos;&gt;Your Feedback has been successfully sended.&lt;/font&gt;</source>
+        <source>&lt;font color=&apos;#2ecc71&apos;&gt;Your Feedback has been successfully sent.&lt;/font&gt;</source>
         <translation>&lt;font color=&apos;#2ecc71&apos;&gt;A visszajelzést sikeresen elküldte.&lt;/font&gt;</translation>
     </message>
     <message>

--- a/translations/stacer_it.ts
+++ b/translations/stacer_it.ts
@@ -306,7 +306,7 @@
     </message>
     <message>
         <location filename="../stacer/Pages/Dashboard/dashboard_page.ui" line="230"/>
-        <source>There are update currently available.</source>
+        <source>There are updates currently available.</source>
         <translation>Ci sono aggiornamenti attualmente disponibili.</translation>
     </message>
     <message>
@@ -440,7 +440,7 @@
     </message>
     <message>
         <location filename="../stacer/feedback.ui" line="104"/>
-        <source>Send a Feedback</source>
+        <source>Send Feedback</source>
         <translation>Invia un Feedback</translation>
     </message>
     <message>
@@ -460,7 +460,7 @@
     </message>
     <message>
         <location filename="../stacer/feedback.cpp" line="79"/>
-        <source>&lt;font color=&apos;#2ecc71&apos;&gt;Your Feedback has been successfully sended.&lt;/font&gt;</source>
+        <source>&lt;font color=&apos;#2ecc71&apos;&gt;Your Feedback has been successfully sent.&lt;/font&gt;</source>
         <translation>&lt;font color=&apos;#2ecc71&apos;&gt;Il tuo Feedback &#232; stato inviato con successo.&lt;/font&gt;</translation>
     </message>
     <message>

--- a/translations/stacer_kn.ts
+++ b/translations/stacer_kn.ts
@@ -306,7 +306,7 @@
     </message>
     <message>
         <location filename="../stacer/Pages/Dashboard/dashboard_page.ui" line="230"/>
-        <source>There are update currently available.</source>
+        <source>There are updates currently available.</source>
         <translation>ನವೀಕರಣಗಳು ಲಭ್ಯವಿವೆ.</translation>
     </message>
     <message>
@@ -440,7 +440,7 @@
     </message>
     <message>
         <location filename="../stacer/feedback.ui" line="104"/>
-        <source>Send a Feedback</source>
+        <source>Send Feedback</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -460,7 +460,7 @@
     </message>
     <message>
         <location filename="../stacer/feedback.cpp" line="79"/>
-        <source>&lt;font color=&apos;#2ecc71&apos;&gt;Your Feedback has been successfully sended.&lt;/font&gt;</source>
+        <source>&lt;font color=&apos;#2ecc71&apos;&gt;Your Feedback has been successfully sent.&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/stacer_ko.ts
+++ b/translations/stacer_ko.ts
@@ -306,7 +306,7 @@
     </message>
     <message>
         <location filename="../stacer/Pages/Dashboard/dashboard_page.ui" line="230"/>
-        <source>There are update currently available.</source>
+        <source>There are updates currently available.</source>
         <translation type="unfinished">프로그램의 최신 업데이트가 있습니다.</translation>
     </message>
     <message>
@@ -440,7 +440,7 @@
     </message>
     <message>
         <location filename="../stacer/feedback.ui" line="104"/>
-        <source>Send a Feedback</source>
+        <source>Send Feedback</source>
         <translation type="unfinished">피드백 보내기</translation>
     </message>
     <message>
@@ -460,7 +460,7 @@
     </message>
     <message>
         <location filename="../stacer/feedback.cpp" line="79"/>
-        <source>&lt;font color=&apos;#2ecc71&apos;&gt;Your Feedback has been successfully sended.&lt;/font&gt;</source>
+        <source>&lt;font color=&apos;#2ecc71&apos;&gt;Your Feedback has been successfully sent.&lt;/font&gt;</source>
         <translation type="unfinished">&lt;font color=&apos;#2ecc71&apos;&gt;피드백 메세지가 성공적으로 전달되었습니다.&lt;/font&gt;</translation>
     </message>
     <message>

--- a/translations/stacer_ml.ts
+++ b/translations/stacer_ml.ts
@@ -316,7 +316,7 @@
     </message>
     <message>
         <location filename="../stacer/Pages/Dashboard/dashboard_page.ui" line="230"/>
-        <source>There are update currently available.</source>
+        <source>There are updates currently available.</source>
         <translation>നിലവിൽ അപ്ഡേറ്റുകൾ ലഭ്യമാണ്.</translation>
     </message>
     <message>
@@ -450,7 +450,7 @@
     </message>
     <message>
         <location filename="../stacer/feedback.ui" line="104"/>
-        <source>Send a Feedback</source>
+        <source>Send Feedback</source>
         <translation>പ്രതികരണം അയക്കുക</translation>
     </message>
     <message>
@@ -470,7 +470,7 @@
     </message>
     <message>
         <location filename="../stacer/feedback.cpp" line="79"/>
-        <source>&lt;font color=&apos;#2ecc71&apos;&gt;Your Feedback has been successfully sended.&lt;/font&gt;</source>
+        <source>&lt;font color=&apos;#2ecc71&apos;&gt;Your Feedback has been successfully sent.&lt;/font&gt;</source>
         <translation>&lt;font color=&apos;#2ecc71&apos;&gt;നിങ്ങളുടെ പ്രതികരണം വിജയകരമായി അയച്ചു.&lt;/font&gt;</translation>
     </message>
     <message>

--- a/translations/stacer_nl.ts
+++ b/translations/stacer_nl.ts
@@ -306,7 +306,7 @@
     </message>
     <message>
         <location filename="../stacer/Pages/Dashboard/dashboard_page.ui" line="230"/>
-        <source>There are update currently available.</source>
+        <source>There are updates currently available.</source>
         <translation>Er zijn updates beschikbaar.</translation>
     </message>
     <message>
@@ -440,7 +440,7 @@
     </message>
     <message>
         <location filename="../stacer/feedback.ui" line="104"/>
-        <source>Send a Feedback</source>
+        <source>Send Feedback</source>
         <translation>Feedback versturen</translation>
     </message>
     <message>
@@ -460,7 +460,7 @@
     </message>
     <message>
         <location filename="../stacer/feedback.cpp" line="79"/>
-        <source>&lt;font color=&apos;#2ecc71&apos;&gt;Your Feedback has been successfully sended.&lt;/font&gt;</source>
+        <source>&lt;font color=&apos;#2ecc71&apos;&gt;Your Feedback has been successfully sent.&lt;/font&gt;</source>
         <translation>&lt;font color=&apos;#2ecc71&apos;&gt;Uw feedback is succesvol verstuurd.&lt;/font&gt;</translation>
     </message>
     <message>

--- a/translations/stacer_oc.ts
+++ b/translations/stacer_oc.ts
@@ -306,7 +306,7 @@
     </message>
     <message>
         <location filename="../stacer/Pages/Dashboard/dashboard_page.ui" line="230"/>
-        <source>There are update currently available.</source>
+        <source>There are updates currently available.</source>
         <translation>I a de mesas a jorn disponiblas</translation>
     </message>
     <message>
@@ -440,7 +440,7 @@
     </message>
     <message>
         <location filename="../stacer/feedback.ui" line="104"/>
-        <source>Send a Feedback</source>
+        <source>Send Feedback</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -460,7 +460,7 @@
     </message>
     <message>
         <location filename="../stacer/feedback.cpp" line="79"/>
-        <source>&lt;font color=&apos;#2ecc71&apos;&gt;Your Feedback has been successfully sended.&lt;/font&gt;</source>
+        <source>&lt;font color=&apos;#2ecc71&apos;&gt;Your Feedback has been successfully sent.&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/stacer_pl.ts
+++ b/translations/stacer_pl.ts
@@ -306,7 +306,7 @@
     </message>
     <message>
         <location filename="../stacer/Pages/Dashboard/dashboard_page.ui" line="230"/>
-        <source>There are update currently available.</source>
+        <source>There are updates currently available.</source>
         <translation>Dostępna jest aktualizacja</translation>
     </message>
     <message>
@@ -440,7 +440,7 @@
     </message>
     <message>
         <location filename="../stacer/feedback.ui" line="104"/>
-        <source>Send a Feedback</source>
+        <source>Send Feedback</source>
          <translation>Wysyłanie informacji zwrotnych</translation>
     </message>
     <message>
@@ -460,7 +460,7 @@
     </message>
     <message>
         <location filename="../stacer/feedback.cpp" line="79"/>
-        <source>&lt;font color=&apos;#2ecc71&apos;&gt;Your Feedback has been successfully sended.&lt;/font&gt;</source>
+        <source>&lt;font color=&apos;#2ecc71&apos;&gt;Your Feedback has been successfully sent.&lt;/font&gt;</source>
         <translation>&lt;font color=&apos;#2ecc71&apos;&gt;Twoje informacje zwrotne zostały wysłane.&lt;/font&gt;</translation>
     </message>
     <message>

--- a/translations/stacer_pt.ts
+++ b/translations/stacer_pt.ts
@@ -306,7 +306,7 @@
     </message>
     <message>
         <location filename="../stacer/Pages/Dashboard/dashboard_page.ui" line="230"/>
-        <source>There are update currently available.</source>
+        <source>There are updates currently available.</source>
         <translation>Há atualizações disponíveis.</translation>
     </message>
     <message>
@@ -440,7 +440,7 @@
     </message>
     <message>
         <location filename="../stacer/feedback.ui" line="104"/>
-        <source>Send a Feedback</source>
+        <source>Send Feedback</source>
         <translation>Enviar um Comentário</translation>
     </message>
     <message>
@@ -460,7 +460,7 @@
     </message>
     <message>
         <location filename="../stacer/feedback.cpp" line="79"/>
-        <source>&lt;font color=&apos;#2ecc71&apos;&gt;Your Feedback has been successfully sended.&lt;/font&gt;</source>
+        <source>&lt;font color=&apos;#2ecc71&apos;&gt;Your Feedback has been successfully sent.&lt;/font&gt;</source>
         <translation>&lt;font color=&apos;#2ecc71&apos;&gt;O seu Comentário foi enviado com sucesso.&lt;/font&gt;</translation>
     </message>
     <message>

--- a/translations/stacer_ro.ts
+++ b/translations/stacer_ro.ts
@@ -306,7 +306,7 @@
     </message>
     <message>
         <location filename="../stacer/Pages/Dashboard/dashboard_page.ui" line="230"/>
-        <source>There are update currently available.</source>
+        <source>There are updates currently available.</source>
         <translation>Există actualizări disponibile în prezent.</translation>
     </message>
     <message>
@@ -440,7 +440,7 @@
     </message>
     <message>
         <location filename="../stacer/feedback.ui" line="104"/>
-        <source>Send a Feedback</source>
+        <source>Send Feedback</source>
         <translation>Trimite un Feedback</translation>
     </message>
     <message>
@@ -460,7 +460,7 @@
     </message>
     <message>
         <location filename="../stacer/feedback.cpp" line="79"/>
-        <source>&lt;font color=&apos;#2ecc71&apos;&gt;Your Feedback has been successfully sended.&lt;/font&gt;</source>
+        <source>&lt;font color=&apos;#2ecc71&apos;&gt;Your Feedback has been successfully sent.&lt;/font&gt;</source>
         <translation>&lt;font color=&apos;#2ecc71&apos;&gt;Feedback-ul dvs. a fost trimis cu succes.&lt;/font&gt;</translation>
     </message>
     <message>

--- a/translations/stacer_ru.ts
+++ b/translations/stacer_ru.ts
@@ -306,7 +306,7 @@
     </message>
     <message>
         <location filename="../stacer/Pages/Dashboard/dashboard_page.ui" line="230"/>
-        <source>There are update currently available.</source>
+        <source>There are updates currently available.</source>
         <translation>Доступно обновление.</translation>
     </message>
     <message>
@@ -440,7 +440,7 @@
     </message>
     <message>
         <location filename="../stacer/feedback.ui" line="104"/>
-        <source>Send a Feedback</source>
+        <source>Send Feedback</source>
         <translation>Отправить отзыв</translation>
     </message>
     <message>
@@ -460,7 +460,7 @@
     </message>
     <message>
         <location filename="../stacer/feedback.cpp" line="79"/>
-        <source>&lt;font color=&apos;#2ecc71&apos;&gt;Your Feedback has been successfully sended.&lt;/font&gt;</source>
+        <source>&lt;font color=&apos;#2ecc71&apos;&gt;Your Feedback has been successfully sent.&lt;/font&gt;</source>
         <translation>&lt;font color=&apos;#2ecc71&apos;&gt;Ваш отзыв был отправлен.&lt;/font&gt;</translation>
     </message>
     <message>

--- a/translations/stacer_sv.ts
+++ b/translations/stacer_sv.ts
@@ -306,7 +306,7 @@
     </message>
     <message>
         <location filename="../stacer/Pages/Dashboard/dashboard_page.ui" line="230"/>
-        <source>There are update currently available.</source>
+        <source>There are updates currently available.</source>
         <translation>Det finns en uppdatering tillgänglig.</translation>
     </message>
     <message>
@@ -440,7 +440,7 @@
     </message>
     <message>
         <location filename="../stacer/feedback.ui" line="104"/>
-        <source>Send a Feedback</source>
+        <source>Send Feedback</source>
         <translation>Skicka återkoppling</translation>
     </message>
     <message>
@@ -460,7 +460,7 @@
     </message>
     <message>
         <location filename="../stacer/feedback.cpp" line="79"/>
-        <source>&lt;font color=&apos;#2ecc71&apos;&gt;Your Feedback has been successfully sended.&lt;/font&gt;</source>
+        <source>&lt;font color=&apos;#2ecc71&apos;&gt;Your Feedback has been successfully sent.&lt;/font&gt;</source>
         <translation>&lt;font color=&apos;#2ecc71&apos;&gt;Din återkoppling har skickats.&lt;/font&gt;</translation>
     </message>
     <message>

--- a/translations/stacer_tr.ts
+++ b/translations/stacer_tr.ts
@@ -306,7 +306,7 @@
     </message>
     <message>
         <location filename="../stacer/Pages/Dashboard/dashboard_page.ui" line="230"/>
-        <source>There are update currently available.</source>
+        <source>There are updates currently available.</source>
         <translation>Şu anda mevcut güncelleme var.</translation>
     </message>
     <message>
@@ -440,7 +440,7 @@
     </message>
     <message>
         <location filename="../stacer/feedback.ui" line="104"/>
-        <source>Send a Feedback</source>
+        <source>Send Feedback</source>
         <translation>Geribildirim Gönder</translation>
     </message>
     <message>
@@ -460,7 +460,7 @@
     </message>
     <message>
         <location filename="../stacer/feedback.cpp" line="79"/>
-        <source>&lt;font color=&apos;#2ecc71&apos;&gt;Your Feedback has been successfully sended.&lt;/font&gt;</source>
+        <source>&lt;font color=&apos;#2ecc71&apos;&gt;Your Feedback has been successfully sent.&lt;/font&gt;</source>
         <translation>&lt;font color=&apos;#2ecc71&apos;&gt;Geribildiriminiz başarıyla gönderildi.&lt;/font&gt;</translation>
     </message>
     <message>

--- a/translations/stacer_ua.ts
+++ b/translations/stacer_ua.ts
@@ -53,7 +53,7 @@
     </message>
     <message>
         <location filename="../stacer/Pages/Dashboard/dashboard_page.ui" line="240"/>
-        <source>There are update currently available.</source>
+        <source>There are updates currently available.</source>
         <translation>Доступно оновлення.</translation>
     </message>
     <message>

--- a/translations/stacer_vn.ts
+++ b/translations/stacer_vn.ts
@@ -53,7 +53,7 @@
     </message>
     <message>
         <location filename="../stacer/Pages/Dashboard/dashboard_page.ui" line="240"/>
-        <source>There are update currently available.</source>
+        <source>There are updates currently available.</source>
         <translation>Có Cập Nhật Mới</translation>
     </message>
     <message>

--- a/translations/stacer_zh-cn.ts
+++ b/translations/stacer_zh-cn.ts
@@ -306,7 +306,7 @@
     </message>
     <message>
         <location filename="../stacer/Pages/Dashboard/dashboard_page.ui" line="230"/>
-        <source>There are update currently available.</source>
+        <source>There are updates currently available.</source>
         <translation>当前有可用更新</translation>
     </message>
     <message>
@@ -440,7 +440,7 @@
     </message>
     <message>
         <location filename="../stacer/feedback.ui" line="104"/>
-        <source>Send a Feedback</source>
+        <source>Send Feedback</source>
         <translation type="finished">发送反馈</translation>
     </message>
     <message>
@@ -460,7 +460,7 @@
     </message>
     <message>
         <location filename="../stacer/feedback.cpp" line="79"/>
-        <source>&lt;font color=&apos;#2ecc71&apos;&gt;Your Feedback has been successfully sended.&lt;/font&gt;</source>
+        <source>&lt;font color=&apos;#2ecc71&apos;&gt;Your Feedback has been successfully sent.&lt;/font&gt;</source>
         <translation type="finished">&lt;font color=&apos;#2ecc71&apos;&gt;反馈发送成功。&lt;/font&gt;</translation>
     </message>
     <message>

--- a/translations/stacer_zh-tw.ts
+++ b/translations/stacer_zh-tw.ts
@@ -53,7 +53,7 @@
     </message>
     <message>
         <location filename="../stacer/Pages/Dashboard/dashboard_page.ui" line="240"/>
-        <source>There are update currently available.</source>
+        <source>There are updates currently available.</source>
         <translation>目前有可用更新</translation>
     </message>
     <message>


### PR DESCRIPTION
Modify "update" to "updates" to align with the use of "are."
Amend "sended" to the correct past tense form, "sent."
Revise "Send a Feedback" to "Send Feedback," since "feedback" is typically uncountable and implies singularity.